### PR TITLE
Fix: Metric Listener

### DIFF
--- a/src/Listener/MetricFlushListener.php
+++ b/src/Listener/MetricFlushListener.php
@@ -13,6 +13,7 @@ use Hyperf\Coroutine\Coroutine;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\BeforeWorkerStart;
 use OpenTelemetry\SDK\Metrics\MetricReaderInterface;
+use Hyperf\Command\Event\BeforeHandle;
 
 class MetricFlushListener implements ListenerInterface
 {
@@ -29,15 +30,12 @@ class MetricFlushListener implements ListenerInterface
     {
         return [
             BeforeWorkerStart::class,
+            BeforeHandle::class,
         ];
     }
 
     public function process(object $event): void
     {
-        if ($event->workerId === null) {
-            return;
-        }
-
         $timerInterval = (int) $this->config->get(
             'open-telemetry.exporter.metrics.flush_interval',
             5

--- a/tests/Unit/Listener/MetricFlushListenerTest.php
+++ b/tests/Unit/Listener/MetricFlushListenerTest.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Listener;
 
+use Hyperf\Command\Event\BeforeHandle;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\ContainerInterface;
 use Hyperf\Coordinator\Constants;
 use Hyperf\Coordinator\CoordinatorManager;
 use Hyperf\Coordinator\Timer;
 use Hyperf\Framework\Event\BeforeWorkerStart;
+use Hyperf\OpenTelemetry\Listener\MetricFlushListener;
 use OpenTelemetry\SDK\Metrics\MetricReaderInterface;
 use PHPUnit\Framework\TestCase;
-use Hyperf\OpenTelemetry\Listener\MetricFlushListener;
-use stdClass;
 use Swoole\Server;
 
 /**
@@ -55,19 +55,7 @@ class MetricFlushListenerTest extends TestCase
     {
         $listener = new MetricFlushListener($this->container, $this->config);
 
-        $this->assertEquals([BeforeWorkerStart::class], $listener->listen());
-    }
-
-    public function testProcessWithNullWorkerIdShouldDoNothing(): void
-    {
-        $event = new stdClass();
-        $event->workerId = null;
-
-        $this->config->expects($this->never())->method('get');
-        $this->container->expects($this->never())->method('has');
-
-        $listener = new MetricFlushListener($this->container, $this->config);
-        $listener->process($event);
+        $this->assertEquals([BeforeWorkerStart::class, BeforeHandle::class], $listener->listen());
     }
 
     public function testProcessWithValidWorkerIdSetsUpTimer(): void


### PR DESCRIPTION
## Description
The `BeforeWorkerStart` event only works for HTTP server workers (Swoole Server processes). It does not execute for CLI commands. To cover both HTTP servers and CLI commands, we need to add the `BeforeHandle` event.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Performance/Refactor
- [ ] CI/CD/Chore

## Checklist
- [x] Title follows *Conventional Commits* (e.g., `feat: add SQS aspect`)
- [x] Tests added/updated
- [x] `composer test` passes locally
- [x] Documentation updated (README/Docs)
- [x] No breaking changes (or documented if any)

## Related issues
Closes #<id>, Relates to #<id>
