### PR TITLE
feat: Adds support for UUID versions 6–8

### DIFF
--- a/src/Aspect/GuzzleClientAspect.php
+++ b/src/Aspect/GuzzleClientAspect.php
@@ -65,7 +65,7 @@ class GuzzleClientAspect extends AbstractAspect
 
         if ($this->isTracingEnabled) {
             $scope = $this->instrumentation->startSpan(
-                name: $method . ' ' . Uri::sanitize($request->getUri()->getPath()),
+                name: $method . ' ' . Uri::sanitize($request->getUri()->getPath(), $this->config->get('open-telemetry.traces.uri_mask', [])),
                 spanKind: SpanKind::KIND_CLIENT,
                 attributes: [
                     HttpAttributes::HTTP_REQUEST_METHOD => $method,
@@ -128,9 +128,12 @@ class GuzzleClientAspect extends AbstractAspect
                     ->createHistogram('http.client.request.duration', 'ms')
                     ->record($duration, [
                         ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),
-                        UrlIncubatingAttributes::URL_TEMPLATE => Uri::sanitize($request->getUri()->getPath()),
                         HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
                         HttpAttributes::HTTP_RESPONSE_STATUS_CODE => $response->getStatusCode(),
+                        UrlIncubatingAttributes::URL_TEMPLATE => Uri::sanitize(
+                            $request->getUri()->getPath(), 
+                            $this->config->get('open-telemetry.metrics.uri_mask', []),
+                        ),
                     ]);
             }
 
@@ -156,8 +159,11 @@ class GuzzleClientAspect extends AbstractAspect
                             ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),
                             HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
                             HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 0,
-                            UrlIncubatingAttributes::URL_TEMPLATE => Uri::sanitize($request->getUri()->getPath()),
                             ErrorAttributes::ERROR_TYPE => get_class($throwable),
+                            UrlIncubatingAttributes::URL_TEMPLATE => Uri::sanitize(
+                                $request->getUri()->getPath(), 
+                                $this->config->get('open-telemetry.traces.uri_mask', []),
+                            ),
                         ]
                     );
             }

--- a/src/Middleware/MetricMiddleware.php
+++ b/src/Middleware/MetricMiddleware.php
@@ -30,8 +30,11 @@ class MetricMiddleware extends AbstractMiddleware
         $startTime = microtime(true);
 
         $attributes = [
-            HttpAttributes::HTTP_ROUTE => Uri::sanitize($request->getUri()->getPath()),
             HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
+            HttpAttributes::HTTP_ROUTE => Uri::sanitize(
+                $request->getUri()->getPath(), 
+                $this->config->get('open-telemetry.metrics.uri_mask', [])
+            ),
         ];
 
         try {

--- a/src/Middleware/TraceMiddleware.php
+++ b/src/Middleware/TraceMiddleware.php
@@ -45,7 +45,10 @@ class TraceMiddleware extends AbstractMiddleware
             attributes: [
                 HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
                 UrlAttributes::URL_FULL => (string) $request->getUri(),
-                UrlAttributes::URL_PATH => $request->getUri()->getPath(),
+                UrlAttributes::URL_PATH => Uri::sanitize(
+                    $request->getUri()->getPath(), 
+                    $this->config->get('open-telemetry.traces.uri_mask', [])
+                ),
                 UrlAttributes::URL_SCHEME => $request->getUri()->getScheme(),
                 UrlAttributes::URL_QUERY => $request->getUri()->getQuery(),
                 ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),

--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -8,8 +8,8 @@ class Uri
 {
     public static function sanitize(string $uri, array $uriMask = []): string
     {
-        // UUID v1–v8 (RFC 4122 + RFC 9562)
-        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?=\/|$)/i';
+        // UUID v1–v8 with any variant
+        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12})(?=\/|$)/i';
 
         $defaultPatterns = [
             $uuid => '/{uuid}',

--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -8,7 +8,8 @@ class Uri
 {
     public static function sanitize(string $uri, array $uriMask = []): string
     {
-        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?=\/|$)/i';
+        // UUID v1–v8 (RFC 4122 + RFC 9562)
+        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?=\/|$)/i';
 
         $defaultPatterns = [
             $uuid => '/{uuid}',

--- a/tests/Unit/Middleware/MetricMiddlewareTest.php
+++ b/tests/Unit/Middleware/MetricMiddlewareTest.php
@@ -104,6 +104,43 @@ class MetricMiddlewareTest extends TestCase
         $this->assertSame($this->response, $result);
     }
 
+    public function testProcessWithUriMaskAndSuccessRequest(): void
+    {
+        $this->config->method('get')
+            ->with('open-telemetry.metrics.uri_mask', [])
+            ->willReturn(['/P2P[0-9A-Za-z]+/' => '{txId}']);
+
+        $this->configureRequestMock('GET', '/users/P2P123');
+        $this->configureResponseMock(200);
+
+        $this->meter->method('createHistogram')
+            ->with(HttpMetrics::HTTP_SERVER_REQUEST_DURATION, 'ms')
+            ->willReturn($this->histogram);
+
+        $expectedAttributes = [
+            HttpAttributes::HTTP_ROUTE => '/users/{txId}',
+            HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
+            HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 200,
+        ];
+
+        $this->histogram->expects($this->once())
+            ->method('record')
+            ->with(
+                $this->greaterThan(0),
+                $expectedAttributes
+            );
+
+        $middleware = new MetricMiddleware(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $result = $middleware->process($this->request, $this->handler);
+
+        $this->assertSame($this->response, $result);
+    }
+
     public function testProcessWithIgnoredPath(): void
     {
         $this->configureRequestMock('GET', '/health');

--- a/tests/Unit/Support/UriTest.php
+++ b/tests/Unit/Support/UriTest.php
@@ -101,4 +101,40 @@ class UriTest extends TestCase
         $result = Uri::sanitize($uri);
         $this->assertSame('/', $result);
     }
+
+    public function testSanitizeUuidV1ToV4()
+    {
+        $uri = '/5c4f7ab3-7849-4422-a262-cd1bfc5ae7ae/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV1ToV5()
+    {
+        $uri = '/123e4567-e89b-12d3-a456-426614174000/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV6()
+    {
+        $uri = '/01000000-9f9e-6094-2a9d-08ddf52351e2/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV7()
+    {
+        $uri = '/01890f28-54c2-7d11-bc99-9bb9d1a9e9af/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV8()
+    {
+        $uri = '/ffffffff-ffff-8fff-9fff-ffffffffffff/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
 }


### PR DESCRIPTION
## 📝 Description
<!-- Explain what this PR does and why it is needed. -->
Adds support for UUID versions 6–8 in the `Uri::sanitize()` method and updates corresponding unit tests to ensure full coverage according to RFC 9562.
Adds support for custom masks.

<img width="982" height="77" alt="image" src="https://github.com/user-attachments/assets/c99da187-d42a-4c79-a9d1-74f4a8f3b824" />


---

## 🔄 Type of change
- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧾 Documentation  
- [ ] ⚡️ Performance/Refactor  
- [ ] 🔧 CI/CD / Chore  

---

## ✅ Checklist
- [x] PR title follows *Conventional Commits* (e.g., `feat: support UUID v6–v8 in sanitize`)
- [x] Unit tests added or updated  
- [x] `composer test` passes locally  
- [x] Documentation updated (README or inline PHPDoc)  
- [x] No breaking changes introduced  

---

## 🔗 Related issues
UUIDs v7 are not masked.
<img width="1004" height="285" alt="image" src="https://github.com/user-attachments/assets/97afd702-fca9-486a-a00a-5b4849bb879b" />

---

## 🧩 Additional context
This PR enhances the `sanitize()` function to recognize and safely mask UUIDs of versions **1–8**, including new formats defined by **RFC 9562 (v6–v8)**.  
New PHPUnit tests were added for each UUID version to ensure accuracy and backward compatibility.
