### PR TITLE
feat: Adds support for UUID versions 6–8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ update:
 	@docker-compose run --rm hyperf-opentelemetry -c "composer update"
 
 test:
-	@docker-compose run --rm hyperf-opentelemetry sh -c "composer test"
+	@docker-compose run --rm hyperf-opentelemetry -c "composer test"
 

--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -8,7 +8,7 @@ class Uri
 {
     public static function sanitize(string $uri, array $uriMask = []): string
     {
-        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?=\/|$)/i';
+        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12})(?=\/|$)/i';
 
         $defaultPatterns = [
             $uuid => '/{uuid}',

--- a/tests/Unit/Support/UriTest.php
+++ b/tests/Unit/Support/UriTest.php
@@ -101,4 +101,40 @@ class UriTest extends TestCase
         $result = Uri::sanitize($uri);
         $this->assertSame('/', $result);
     }
+
+    public function testSanitizeUuidV1ToV4()
+    {
+        $uri = '/5c4f7ab3-7849-4422-a262-cd1bfc5ae7ae/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV1ToV5()
+    {
+        $uri = '/123e4567-e89b-12d3-a456-426614174000/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV6()
+    {
+        $uri = '/01000000-9f9e-6094-2a9d-08ddf52351e2/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV7()
+    {
+        $uri = '/01890f28-54c2-7d11-bc99-9bb9d1a9e9af/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
+    public function testSanitizeUuidV8()
+    {
+        $uri = '/ffffffff-ffff-8fff-9fff-ffffffffffff/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
 }


### PR DESCRIPTION
## 📝 Description
<!-- Explain what this PR does and why it is needed. -->
Adds support for the uri_mask parameter, enabling customization of masking patterns according to the specific context and requirements of the consuming service.

<img width="982" height="77" alt="image" src="https://github.com/user-attachments/assets/c99da187-d42a-4c79-a9d1-74f4a8f3b824" />


---

## 🔄 Type of change
- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧾 Documentation  
- [ ] ⚡️ Performance/Refactor  
- [ ] 🔧 CI/CD / Chore  

---

## ✅ Checklist
- [x] PR title follows *Conventional Commits* (e.g., `feat: support UUID v6–v8 in sanitize`)
- [x] Unit tests added or updated  
- [x] `composer test` passes locally  
- [x] Documentation updated (README or inline PHPDoc)  
- [x] No breaking changes introduced  

---

## 🔗 Related issues
UUIDs v7 are not masked.
<img width="1004" height="285" alt="image" src="https://github.com/user-attachments/assets/97afd702-fca9-486a-a00a-5b4849bb879b" />

---

## 🧩 Additional context
References:
- https://github.com/opencodeco/hyperf-metric/blob/330180752367428115fa0251f7ee48680a192abe/src/Aspect/HttpClientMetricAspect.php#L104
- https://github.com/opencodeco/hyperf-tracer/blob/1304c995884485fb9349f32dbe825f59949d2d79/src/Aspect/HttpClientAspect.php#L131
- https://github.com/opencodeco/hyperf-tracer/blob/1304c995884485fb9349f32dbe825f59949d2d79/src/Middleware/TraceMiddleware.php#L174