### PR TITLE
feat: add uri_mask support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ update:
 	@docker-compose run --rm hyperf-opentelemetry -c "composer update"
 
 test:
-	@docker-compose run --rm hyperf-opentelemetry sh -c "composer test"
+	@docker-compose run --rm hyperf-opentelemetry -c "composer test"
 

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ update:
 	@docker-compose run --rm hyperf-opentelemetry -c "composer update"
 
 test:
-	@docker-compose run --rm hyperf-opentelemetry -c "composer test"
+	@docker-compose run --rm hyperf-opentelemetry sh -c "composer test"
 

--- a/publish/open-telemetry.php
+++ b/publish/open-telemetry.php
@@ -35,6 +35,7 @@ return [
         'export_interval' => (int) env('OTEL_TRACES_EXPORT_INTERVAL', 5),
         'processor' => env('OTEL_TRACES_PROCESSOR', 'batch'),
         'sampler' => env('OTEL_TRACES_SAMPLER', 'always_on'),
+        'uri_mask' => [],
         'exporters' => [
             'otlp_http' => [
                 'driver' => OtlpHttpTraceExporterFactory::class,
@@ -80,6 +81,7 @@ return [
         'enabled' => env('OTEL_METRICS_ENABLED', true),
         'exporter' => env('OTEL_METRICS_EXPORTER', 'otlp_http'),
         'export_interval' => (int) env('OTEL_METRICS_EXPORT_INTERVAL', 5),
+        'uri_mask' => [],
         'exporters' => [
             'otlp_http' => [
                 'driver' => OtlpHttpMetricExporterFactory::class,

--- a/src/Aspect/GuzzleClientAspect.php
+++ b/src/Aspect/GuzzleClientAspect.php
@@ -63,16 +63,17 @@ class GuzzleClientAspect extends AbstractAspect
             return $proceedingJoinPoint->process();
         }
 
-        $path = Uri::sanitize($request->getUri()->getPath(), $this->config->get('open-telemetry.traces.uri_mask', []));
-
         if ($this->isTracingEnabled) {
             $scope = $this->instrumentation->startSpan(
-                name: $method . ' ' . $path,
+                name: $method . ' ' .  Uri::sanitize(
+                    $request->getUri()->getPath(),
+                    $this->config->get('open-telemetry.traces.uri_mask', [])
+                ),
                 spanKind: SpanKind::KIND_CLIENT,
                 attributes: [
                     HttpAttributes::HTTP_REQUEST_METHOD => $method,
                     UrlAttributes::URL_FULL => (string) $request->getUri(),
-                    UrlAttributes::URL_PATH => $path,
+                    UrlAttributes::URL_PATH => $request->getUri()->getPath(),
                     UrlAttributes::URL_SCHEME => $request->getUri()->getScheme(),
                     UrlAttributes::URL_QUERY => $request->getUri()->getQuery(),
                     ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),

--- a/src/Middleware/MetricMiddleware.php
+++ b/src/Middleware/MetricMiddleware.php
@@ -30,8 +30,11 @@ class MetricMiddleware extends AbstractMiddleware
         $startTime = microtime(true);
 
         $attributes = [
-            HttpAttributes::HTTP_ROUTE => Uri::sanitize($request->getUri()->getPath()),
             HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
+            HttpAttributes::HTTP_ROUTE => Uri::sanitize(
+                $request->getUri()->getPath(),
+                $this->config->get('open-telemetry.metrics.uri_mask', [])
+            ),
         ];
 
         try {

--- a/src/Middleware/TraceMiddleware.php
+++ b/src/Middleware/TraceMiddleware.php
@@ -37,7 +37,7 @@ class TraceMiddleware extends AbstractMiddleware
         }
 
         $context = $this->instrumentation->propagator()->extract($request->getHeaders());
-        $name = Uri::sanitize($path);
+        $name = Uri::sanitize($path, $this->config->get('open-telemetry.traces.uri_mask', []));
 
         $scope = $this->instrumentation->startSpan(
             name: $name,
@@ -45,7 +45,7 @@ class TraceMiddleware extends AbstractMiddleware
             attributes: [
                 HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
                 UrlAttributes::URL_FULL => (string) $request->getUri(),
-                UrlAttributes::URL_PATH => $request->getUri()->getPath(),
+                UrlAttributes::URL_PATH => $name,
                 UrlAttributes::URL_SCHEME => $request->getUri()->getScheme(),
                 UrlAttributes::URL_QUERY => $request->getUri()->getQuery(),
                 ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),

--- a/src/Middleware/TraceMiddleware.php
+++ b/src/Middleware/TraceMiddleware.php
@@ -37,15 +37,14 @@ class TraceMiddleware extends AbstractMiddleware
         }
 
         $context = $this->instrumentation->propagator()->extract($request->getHeaders());
-        $name = Uri::sanitize($path, $this->config->get('open-telemetry.traces.uri_mask', []));
 
         $scope = $this->instrumentation->startSpan(
-            name: $name,
+            name: Uri::sanitize($path, $this->config->get('open-telemetry.traces.uri_mask', [])),
             spanKind: SpanKind::KIND_SERVER,
             attributes: [
                 HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
                 UrlAttributes::URL_FULL => (string) $request->getUri(),
-                UrlAttributes::URL_PATH => $name,
+                UrlAttributes::URL_PATH => $request->getUri()->getPath(),
                 UrlAttributes::URL_SCHEME => $request->getUri()->getScheme(),
                 UrlAttributes::URL_QUERY => $request->getUri()->getQuery(),
                 ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),

--- a/tests/Unit/Aspect/GuzzleClientAspectTest.php
+++ b/tests/Unit/Aspect/GuzzleClientAspectTest.php
@@ -165,7 +165,7 @@ class GuzzleClientAspectTest extends TestCase
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
                     UrlAttributes::URL_FULL => 'https://api.example.com/v1/users/12/transactions?page=1',
-                    UrlAttributes::URL_PATH => '/v1/users/{number}/transactions',
+                    UrlAttributes::URL_PATH => '/v1/users/12/transactions',
                     UrlAttributes::URL_SCHEME => 'https',
                     UrlAttributes::URL_QUERY => 'page=1',
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',
@@ -254,7 +254,7 @@ class GuzzleClientAspectTest extends TestCase
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
                     UrlAttributes::URL_FULL => 'https://api.example.com/v1/users/P2P123/transactions?page=1',
-                    UrlAttributes::URL_PATH => '/v1/users/{identifier}/transactions',
+                    UrlAttributes::URL_PATH => '/v1/users/P2P123/transactions',
                     UrlAttributes::URL_SCHEME => 'https',
                     UrlAttributes::URL_QUERY => 'page=1',
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',

--- a/tests/Unit/Aspect/GuzzleClientAspectTest.php
+++ b/tests/Unit/Aspect/GuzzleClientAspectTest.php
@@ -253,7 +253,7 @@ class GuzzleClientAspectTest extends TestCase
                 $this->equalTo(SpanKind::KIND_CLIENT),
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
-                    UrlAttributes::URL_FULL => 'https://api.example.com/v1/users/{identifier}/transactions?page=1',
+                    UrlAttributes::URL_FULL => 'https://api.example.com/v1/users/P2P123/transactions?page=1',
                     UrlAttributes::URL_PATH => '/v1/users/{identifier}/transactions',
                     UrlAttributes::URL_SCHEME => 'https',
                     UrlAttributes::URL_QUERY => 'page=1',

--- a/tests/Unit/Aspect/GuzzleClientAspectTest.php
+++ b/tests/Unit/Aspect/GuzzleClientAspectTest.php
@@ -86,6 +86,8 @@ class GuzzleClientAspectTest extends TestCase
                 ['open-telemetry.metrics.exporters.otlp_http.options.endpoint', 'localhost', 'http://collector:4318'],
                 ['open-telemetry.instrumentation.features.guzzle.options.headers.request', ['*'], ['*']],
                 ['open-telemetry.instrumentation.features.guzzle.options.headers.response', ['*'], ['*']],
+                ['open-telemetry.traces.uri_mask', [], ['/P2P[0-9A-Za-z]+/' => '{identifier}']],
+                ['open-telemetry.metrics.uri_mask', [], ['/P2P[0-9A-Za-z]+/' => '{identifier}']],
             ]);
 
         $this->proceedingJoinPoint->arguments = ['keys' => ['request' => $this->request]];
@@ -163,7 +165,7 @@ class GuzzleClientAspectTest extends TestCase
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
                     UrlAttributes::URL_FULL => 'https://api.example.com/v1/users/12/transactions?page=1',
-                    UrlAttributes::URL_PATH => '/v1/users/12/transactions',
+                    UrlAttributes::URL_PATH => '/v1/users/{number}/transactions',
                     UrlAttributes::URL_SCHEME => 'https',
                     UrlAttributes::URL_QUERY => 'page=1',
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',
@@ -206,6 +208,95 @@ class GuzzleClientAspectTest extends TestCase
                 [
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',
                     UrlIncubatingAttributes::URL_TEMPLATE => '/v1/users/{number}/transactions',
+                    HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
+                    HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 200,
+                ]
+            );
+
+        $result = $aspect->process($this->proceedingJoinPoint);
+
+        $this->assertEquals($this->promise, $result);
+    }
+    public function testProcessWithUriMaskAndSuccessRequest(): void
+    {
+        $this->configureRequestMock(
+            'GET',
+            'https://api.example.com/v1/users/P2P123/transactions?page=1',
+            ['User-Agent' => ['TestAgent/1.0']]
+        );
+
+        $this->configureResponseMock();
+
+        $aspect = new GuzzleClientAspect(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $this->promise->expects($this->once())
+            ->method('then')
+            ->willReturnCallback(function ($fullFilled, $rejected) {
+                $this->assertIsCallable($fullFilled);
+                $this->assertIsCallable($rejected);
+
+                $fullFilled($this->response);
+
+                return $this->promise;
+            });
+
+        // Span
+        $this->instrumentation
+            ->expects($this->once())
+            ->method('startSpan')
+            ->with(
+                $this->equalTo('GET /v1/users/{identifier}/transactions'),
+                $this->equalTo(SpanKind::KIND_CLIENT),
+                [
+                    HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
+                    UrlAttributes::URL_FULL => 'https://api.example.com/v1/users/{identifier}/transactions?page=1',
+                    UrlAttributes::URL_PATH => '/v1/users/{identifier}/transactions',
+                    UrlAttributes::URL_SCHEME => 'https',
+                    UrlAttributes::URL_QUERY => 'page=1',
+                    ServerAttributes::SERVER_ADDRESS => 'api.example.com',
+                    ServerAttributes::SERVER_PORT => 443,
+                    UserAgentAttributes::USER_AGENT_ORIGINAL => 'TestAgent/1.0',
+                    'http.request.header.user-agent' => 'TestAgent/1.0',
+                ]
+            )
+            ->willReturn($this->spanScope);
+
+        $this->propagator->expects($this->once())
+            ->method('inject')
+            ->with($this->request, $this->anything(), $this->spanScope->getContext());
+
+        $this->spanScope->expects($this->once())->method('detach');
+
+        $this->spanScope->expects($this->never())->method('setStatus');
+
+        $this->spanScope->expects($this->once())
+            ->method('setAttributes')
+            ->with([
+                HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 200,
+                HttpIncubatingAttributes::HTTP_RESPONSE_BODY_SIZE => '1024',
+                'http.response.header.content-type' => 'application/json',
+                'http.response.header.content-length' => '1024',
+            ]);
+
+        $this->spanScope->expects($this->once())->method('end');
+
+        // Metric
+        $this->meter->expects($this->once())
+            ->method('createHistogram')
+            ->with('http.client.request.duration', 'ms')
+            ->willReturn($this->histogram);
+
+        $this->histogram->expects($this->once())
+            ->method('record')
+            ->with(
+                $this->isType('float'),
+                [
+                    ServerAttributes::SERVER_ADDRESS => 'api.example.com',
+                    UrlIncubatingAttributes::URL_TEMPLATE => '/v1/users/{identifier}/transactions',
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
                     HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 200,
                 ]

--- a/tests/Unit/Middleware/TraceMiddlewareTest.php
+++ b/tests/Unit/Middleware/TraceMiddlewareTest.php
@@ -73,6 +73,8 @@ class TraceMiddlewareTest extends TestCase
             ->willReturnMap([
                 ['open-telemetry.instrumentation.features.client_request.options.ignore_paths', [], []],
                 ['open-telemetry.instrumentation.features.client_request.options.headers.response', ['*'], ['*']],
+                ['open-telemetry.traces.uri_mask', [], ['/P2P[0-9A-Za-z]+/' => '{identifier}']],
+                ['open-telemetry.metrics.uri_mask', [], ['/P2P[0-9A-Za-z]+/' => '{identifier}']],
             ]);
     }
 
@@ -143,7 +145,70 @@ class TraceMiddlewareTest extends TestCase
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
                     UrlAttributes::URL_FULL => 'https://api.example.com:443/users/12?limit=10',
-                    UrlAttributes::URL_PATH => '/users/12',
+                    UrlAttributes::URL_PATH => '/users/{number}',
+                    UrlAttributes::URL_SCHEME => 'https',
+                    UrlAttributes::URL_QUERY => 'limit=10',
+                    ServerAttributes::SERVER_ADDRESS => 'api.example.com',
+                    ServerAttributes::SERVER_PORT => 443,
+                    UserAgentAttributes::USER_AGENT_ORIGINAL => 'TestAgent/1.0',
+                    ClientAttributes::CLIENT_ADDRESS => '192.168.1.100',
+                ],
+                $this->isType('int'),
+                $context
+            )
+            ->willReturn($spanScope);
+
+        $spanScope->expects($this->once())
+            ->method('setAttributes')
+            ->with([
+                HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 200,
+                HttpIncubatingAttributes::HTTP_RESPONSE_BODY_SIZE => '1024',
+                'http.response.header.content-type' => 'application/json',
+                'http.response.header.content-length' => '1024',
+            ]);
+
+        $spanScope->expects($this->once())->method('end');
+
+        $middleware = new TraceMiddleware(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $result = $middleware->process($this->request, $this->handler);
+
+        $this->assertSame($this->response, $result);
+    }
+
+    public function testProcessWithUriMaskAndSuccessRequest(): void
+    {
+        $this->configureRequestMock('GET', 'https://api.example.com:443/users/P2P123?limit=10');
+        $this->configureResponseMock(200);
+
+        $spanScope = $this->createMock(SpanScope::class);
+
+        $propagator = $this->createMock(TextMapPropagatorInterface::class);
+        $propagator->expects($this->once())
+            ->method('extract')
+            ->with([
+                'User-Agent' => ['TestAgent/1.0'],
+                'x-forwarded-for' => ['192.168.1.100'],
+                'remote-host' => [''],
+                'x-real-ip' => [''],
+            ])
+            ->willReturn($context = $this->createMock(ContextInterface::class));
+
+        $this->instrumentation->expects($this->once())->method('propagator')->willReturn($propagator);
+
+        $this->instrumentation->expects($this->once())
+            ->method('startSpan')
+            ->with(
+                '/users/{identifier}',
+                SpanKind::KIND_SERVER,
+                [
+                    HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
+                    UrlAttributes::URL_FULL => 'https://api.example.com:443/users/P2P123?limit=10',
+                    UrlAttributes::URL_PATH => '/users/{identifier}',
                     UrlAttributes::URL_SCHEME => 'https',
                     UrlAttributes::URL_QUERY => 'limit=10',
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',

--- a/tests/Unit/Middleware/TraceMiddlewareTest.php
+++ b/tests/Unit/Middleware/TraceMiddlewareTest.php
@@ -145,7 +145,7 @@ class TraceMiddlewareTest extends TestCase
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
                     UrlAttributes::URL_FULL => 'https://api.example.com:443/users/12?limit=10',
-                    UrlAttributes::URL_PATH => '/users/{number}',
+                    UrlAttributes::URL_PATH => '/users/12',
                     UrlAttributes::URL_SCHEME => 'https',
                     UrlAttributes::URL_QUERY => 'limit=10',
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',
@@ -208,7 +208,7 @@ class TraceMiddlewareTest extends TestCase
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
                     UrlAttributes::URL_FULL => 'https://api.example.com:443/users/P2P123?limit=10',
-                    UrlAttributes::URL_PATH => '/users/{identifier}',
+                    UrlAttributes::URL_PATH => '/users/P2P123',
                     UrlAttributes::URL_SCHEME => 'https',
                     UrlAttributes::URL_QUERY => 'limit=10',
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',


### PR DESCRIPTION
## 📝 Description
<!-- Explain what this PR does and why it is needed. -->
Adds support for the uri_mask parameter, enabling customization of masking patterns according to the specific context and requirements of the consuming service.

<img width="982" height="77" alt="image" src="https://github.com/user-attachments/assets/c99da187-d42a-4c79-a9d1-74f4a8f3b824" />


---

## 🔄 Type of change
- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧾 Documentation  
- [ ] ⚡️ Performance/Refactor  
- [ ] 🔧 CI/CD / Chore  

---

## ✅ Checklist
- [x] PR title follows *Conventional Commits* (e.g., `feat: support UUID v6–v8 in sanitize`)
- [x] Unit tests added or updated  
- [x] `composer test` passes locally  
- [x] Documentation updated (README or inline PHPDoc)  
- [x] No breaking changes introduced  

---

## 🔗 Related issues
UUIDs v7 are not masked.
<img width="1004" height="285" alt="image" src="https://github.com/user-attachments/assets/97afd702-fca9-486a-a00a-5b4849bb879b" />

---

## 🧩 Additional context
References:
- https://github.com/opencodeco/hyperf-metric/blob/330180752367428115fa0251f7ee48680a192abe/src/Aspect/HttpClientMetricAspect.php#L104
- https://github.com/opencodeco/hyperf-tracer/blob/1304c995884485fb9349f32dbe825f59949d2d79/src/Aspect/HttpClientAspect.php#L131
- https://github.com/opencodeco/hyperf-tracer/blob/1304c995884485fb9349f32dbe825f59949d2d79/src/Middleware/TraceMiddleware.php#L174