### PR TITLE
feat: add Mongo Aspect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM hyperf/hyperf:8.3-alpine-v3.20-swoole
 
 WORKDIR /opt/www
 
+RUN apk add --no-cache php83-pecl-pcov=1.0.11-r0
+
 COPY ./composer.* /opt/www
 RUN composer install --prefer-dist
 COPY . /opt/www

--- a/Makefile
+++ b/Makefile
@@ -11,5 +11,5 @@ update:
 	@docker-compose run --rm hyperf-opentelemetry -c "composer update"
 
 test:
-	@docker-compose run --rm hyperf-opentelemetry sh -c "composer test"
+	@docker-compose run --rm hyperf-opentelemetry -c "composer test"
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This library enables instrumentation of Hyperf-based applications for exporting 
   - Redis
   - Guzzle
   - SQL queries (Hyperf\Database)
+  - MongoDB (GoTask)
 - ♻️ Integration with Swoole ContextStorage
 
 ---

--- a/src/Aspect/Aws/SqsClientAspect.php
+++ b/src/Aspect/Aws/SqsClientAspect.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Hyperf\OpenTelemetry\Aspect\Aws;
 
 use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Hyperf\OpenTelemetry\Aspect\AbstractAspect;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 use OpenTelemetry\SemConv\Incubating\Attributes\MessagingIncubatingAttributes as Msg;
-use Hyperf\OpenTelemetry\Aspect\AbstractAspect;
 use Throwable;
 
 class SqsClientAspect extends AbstractAspect
@@ -33,7 +33,7 @@ class SqsClientAspect extends AbstractAspect
 
         $operationType = $this->resolveOperationType($operation);
 
-        $queueName = $this->extractQueueName($input['QueueUrl'] ?? 'unknown');
+        $queueName = $input['QueueName'] ?? $this->extractQueueName($input['QueueUrl'] ?? 'unknown');
         $queueUrl = $input['QueueUrl'] ?? 'unknown';
 
         $spanKind = ($operationType == 'send') ? SpanKind::KIND_PRODUCER : SpanKind::KIND_CLIENT;
@@ -114,6 +114,7 @@ class SqsClientAspect extends AbstractAspect
             'receivemessage' => Msg::MESSAGING_OPERATION_TYPE_VALUE_RECEIVE,
             'createqueue' => Msg::MESSAGING_OPERATION_TYPE_VALUE_CREATE,
             'deletemessage', 'deletemessagebatch', 'purgequeue' => Msg::MESSAGING_OPERATION_TYPE_VALUE_SETTLE,
+            'getqueueurl' => 'describe',
             default => 'unknown',
         };
     }

--- a/src/Aspect/MongoAspect.php
+++ b/src/Aspect/MongoAspect.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\OpenTelemetry\Aspect;
+
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Hyperf\OpenTelemetry\Aspect\AbstractAspect;
+use Hyperf\Stringable\Str;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\SemConv\Attributes\DbAttributes;
+use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
+use OpenTelemetry\SemConv\Incubating\Attributes\DbIncubatingAttributes;
+use OpenTelemetry\SemConv\Metrics\DbMetrics;
+use ReflectionProperty;
+use Throwable;
+
+class MongoAspect extends AbstractAspect
+{
+    public array $classes = [
+        'Hyperf\GoTask\MongoClient\Collection',
+    ];
+
+    public array $annotations = [];
+
+    protected array $ignoredMethods = [
+        'makePayload',
+    ];
+
+    public function process(ProceedingJoinPoint $proceedingJoinPoint)
+    {
+        if (! $this->isTelemetryEnabled()) {
+            return $proceedingJoinPoint->process();
+        }
+
+        if (in_array($proceedingJoinPoint->methodName, $this->ignoredMethods)) {
+            return $proceedingJoinPoint->process();
+        }
+
+        $method = $proceedingJoinPoint->methodName;
+
+        $operation = Str::upper($method);
+        $collection = $this->getCollectionName($proceedingJoinPoint);
+        $driver = DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_MONGODB;
+
+        $scope = null;
+        $start = microtime(true);
+        $metricErrors = [];
+
+        if ($this->isTracingEnabled) {
+            $scope = $this->instrumentation->startSpan(
+                name: "{$driver} {$operation} {$collection}",
+                spanKind: SpanKind::KIND_CLIENT,
+                attributes: [
+                    DbAttributes::DB_SYSTEM_NAME => $driver,
+                    DbAttributes::DB_COLLECTION_NAME => $collection,
+                    DbAttributes::DB_OPERATION_NAME => $operation,
+                    'db.system' => $driver,
+                    'db.operation' => $operation,
+                    'db.collection' => $collection,
+                ],
+            );
+        }
+
+        try {
+            $result = $proceedingJoinPoint->process();
+            $scope?->setStatus(StatusCode::STATUS_OK);
+        } catch (Throwable $e) {
+            $scope?->recordException($e);
+
+            $metricErrors = [
+                ErrorAttributes::ERROR_TYPE => get_class($e),
+            ];
+
+            throw $e;
+        } finally {
+            $scope?->end();
+
+            if ($this->isMetricsEnabled) {
+                $duration = (microtime(true) - $start) * 1000;
+
+                $this->instrumentation->meter()
+                    ->createHistogram(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+                    ->record(
+                        $duration,
+                        array_merge($metricErrors, [
+                            DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_MONGODB,
+                            DbAttributes::DB_OPERATION_NAME => $operation,
+                        ])
+                    );
+            }
+        }
+
+        return $result;
+    }
+
+    protected function featureName(): string
+    {
+        return 'db_query';
+    }
+
+    private function getCollectionName(ProceedingJoinPoint $proceedingJoinPoint): string
+    {
+        $collection = $proceedingJoinPoint->getInstance();
+
+        $property = new ReflectionProperty('Hyperf\GoTask\MongoClient\Collection', 'collection');
+
+        return $property->getValue($collection);
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace Hyperf\OpenTelemetry;
 
+use Hyperf\OpenTelemetry\Factory\CachedInstrumentationFactory;
 use Hyperf\OpenTelemetry\Factory\Log\LoggerProviderFactory;
 use Hyperf\OpenTelemetry\Factory\Metric\MeterProviderFactory;
+use Hyperf\OpenTelemetry\Factory\OTelResourceFactory;
 use Hyperf\OpenTelemetry\Factory\Trace\TracerProviderFactory;
 use OpenTelemetry\API\Instrumentation\CachedInstrumentation;
 use OpenTelemetry\SDK\Logs\LoggerProviderInterface;
 use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
-use Hyperf\OpenTelemetry\Factory\CachedInstrumentationFactory;
-use Hyperf\OpenTelemetry\Factory\OTelResourceFactory;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
 class ConfigProvider
@@ -44,6 +44,7 @@ class ConfigProvider
                 Aspect\Aws\DynamoDbClientAspect::class,
                 Aspect\Aws\SnsClientAspect::class,
                 Aspect\Aws\SqsClientAspect::class,
+                Aspect\MongoAspect::class,
             ],
             'publish' => [
                 [

--- a/tests/Unit/Aspect/MongoAspectTest.php
+++ b/tests/Unit/Aspect/MongoAspectTest.php
@@ -1,0 +1,389 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Aspect;
+
+use Exception;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+use Hyperf\OpenTelemetry\Aspect\MongoAspect;
+use Hyperf\OpenTelemetry\Instrumentation;
+use Hyperf\OpenTelemetry\Support\SpanScope;
+use Hyperf\OpenTelemetry\Switcher;
+use OpenTelemetry\API\Metrics\HistogramInterface;
+use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\API\Trace\SpanKind;
+use OpenTelemetry\API\Trace\StatusCode;
+use OpenTelemetry\SemConv\Attributes\DbAttributes;
+use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
+use OpenTelemetry\SemConv\Incubating\Attributes\DbIncubatingAttributes;
+use OpenTelemetry\SemConv\Metrics\DbMetrics;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+class MongoAspectTest extends TestCase
+{
+    private ConfigInterface $config;
+
+    private Instrumentation $instrumentation;
+
+    private Switcher $switcher;
+
+    private ProceedingJoinPoint $proceedingJoinPoint;
+
+    private object $mongoCollection;
+
+    private SpanScope $spanScope;
+
+    private MeterInterface $meter;
+
+    private HistogramInterface $histogram;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->config = $this->createMock(ConfigInterface::class);
+        $this->instrumentation = $this->createMock(Instrumentation::class);
+        $this->switcher = $this->createMock(Switcher::class);
+        $this->proceedingJoinPoint = $this->createMock(ProceedingJoinPoint::class);
+        $this->spanScope = $this->createMock(SpanScope::class);
+        $this->meter = $this->createMock(MeterInterface::class);
+        $this->histogram = $this->createMock(HistogramInterface::class);
+
+        $this->instrumentation->method('meter')->willReturn($this->meter);
+
+        if (!class_exists('Hyperf\GoTask\MongoClient\Collection')) {
+            eval('
+                namespace Hyperf\GoTask\MongoClient {
+                    class Collection {
+                        private string $collection = "users";
+                    }
+                }
+            ');
+        }
+
+        $this->mongoCollection = new \Hyperf\GoTask\MongoClient\Collection();
+
+        $reflection = new \ReflectionProperty(\Hyperf\GoTask\MongoClient\Collection::class, 'collection');
+        $reflection->setAccessible(true);
+        $reflection->setValue($this->mongoCollection, 'users');
+
+        $this->switcher->method('isTracingEnabled')->willReturn(true);
+        $this->switcher->method('isMetricsEnabled')->willReturn(true);
+
+        $this->proceedingJoinPoint->method('getInstance')->willReturn($this->mongoCollection);
+    }
+
+    public function testProcessWhenTelemetryIsDisabled(): void
+    {
+        $switcher = $this->createMock(Switcher::class);
+        $switcher->method('isTracingEnabled')->willReturn(false);
+        $switcher->method('isMetricsEnabled')->willReturn(false);
+
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $switcher
+        );
+
+        $this->proceedingJoinPoint->methodName = 'find';
+
+        $expectedResult = [['_id' => '123', 'name' => 'John']];
+        $this->proceedingJoinPoint->expects($this->once())
+            ->method('process')
+            ->willReturn($expectedResult);
+
+        $this->instrumentation->expects($this->never())->method('startSpan');
+        $this->meter->expects($this->never())->method('createHistogram');
+
+        $result = $aspect->process($this->proceedingJoinPoint);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testProcessWithIgnoredMethod(): void
+    {
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $this->proceedingJoinPoint->methodName = 'makePayload';
+
+        $expectedResult = ['key' => 'value'];
+        $this->proceedingJoinPoint->expects($this->once())
+            ->method('process')
+            ->willReturn($expectedResult);
+
+        $this->instrumentation->expects($this->never())->method('startSpan');
+        $this->meter->expects($this->never())->method('createHistogram');
+
+        $result = $aspect->process($this->proceedingJoinPoint);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testProcess(): void
+    {
+        $this->proceedingJoinPoint->methodName = 'find';
+
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $this->instrumentation
+            ->expects($this->once())
+            ->method('startSpan')
+            ->with(
+                $this->equalTo('mongodb FIND users'),
+                $this->equalTo(SpanKind::KIND_CLIENT),
+                $this->equalTo([
+                    DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_MONGODB,
+                    DbAttributes::DB_COLLECTION_NAME => 'users',
+                    DbAttributes::DB_OPERATION_NAME => 'FIND',
+                    'db.system' => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_MONGODB,
+                    'db.operation' => 'FIND',
+                    'db.collection' => 'users',
+                ])
+            )
+            ->willReturn($this->spanScope);
+
+        $this->spanScope->expects($this->once())
+            ->method('setStatus')
+            ->with(StatusCode::STATUS_OK);
+
+        $this->spanScope->expects($this->once())->method('end');
+
+        $this->meter->expects($this->once())
+            ->method('createHistogram')
+            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->willReturn($this->histogram);
+
+        $this->histogram->expects($this->once())
+            ->method('record')
+            ->with(
+                $this->isType('float'),
+                $this->equalTo([
+                    DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_MONGODB,
+                    DbAttributes::DB_OPERATION_NAME => 'FIND',
+                ])
+            );
+
+        $expectedResult = [['_id' => '123', 'name' => 'John']];
+        $this->proceedingJoinPoint->expects($this->once())
+            ->method('process')
+            ->willReturn($expectedResult);
+
+        $result = $aspect->process($this->proceedingJoinPoint);
+
+        $this->assertEquals($expectedResult, $result);
+    }
+
+    public function testProcessWithDifferentMethods(): void
+    {
+        $methods = ['insertOne', 'updateOne', 'deleteOne', 'aggregate'];
+
+        foreach ($methods as $method) {
+            $instrumentation = $this->createMock(Instrumentation::class);
+            $instrumentation->method('meter')->willReturn($this->meter);
+            
+            $spanScope = $this->createMock(SpanScope::class);
+            $spanScope->expects($this->once())->method('setStatus');
+            $spanScope->expects($this->once())->method('end');
+
+            $aspect = new MongoAspect(
+                $this->config,
+                $instrumentation,
+                $this->switcher
+            );
+
+            $proceedingJoinPoint = $this->createMock(ProceedingJoinPoint::class);
+            $proceedingJoinPoint->methodName = $method;
+            $proceedingJoinPoint->method('getInstance')->willReturn($this->mongoCollection);
+
+            $expectedOperation = strtoupper($method);
+
+            $instrumentation
+                ->expects($this->once())
+                ->method('startSpan')
+                ->with(
+                    $this->equalTo("mongodb {$expectedOperation} users"),
+                    $this->anything(),
+                    $this->callback(function ($attributes) use ($expectedOperation) {
+                        return $attributes[DbAttributes::DB_OPERATION_NAME] === $expectedOperation;
+                    })
+                )
+                ->willReturn($spanScope);
+
+            $proceedingJoinPoint->expects($this->once())
+                ->method('process')
+                ->willReturn([]);
+
+            $aspect->process($proceedingJoinPoint);
+        }
+    }
+
+    public function testProcessWithException(): void
+    {
+        $this->proceedingJoinPoint->methodName = 'insertOne';
+
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $this->instrumentation
+            ->expects($this->once())
+            ->method('startSpan')
+            ->with('mongodb INSERTONE users')
+            ->willReturn($this->spanScope);
+
+        $this->meter->expects($this->once())
+            ->method('createHistogram')
+            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->willReturn($this->histogram);
+
+        $this->histogram->expects($this->once())
+            ->method('record')
+            ->with(
+                $this->isType('float'),
+                [
+                    ErrorAttributes::ERROR_TYPE => Exception::class,
+                    DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_MONGODB,
+                    DbAttributes::DB_OPERATION_NAME => 'INSERTONE',
+                ]
+            );
+
+        $exception = new Exception('MongoDB error');
+
+        $this->proceedingJoinPoint->expects($this->once())
+            ->method('process')
+            ->willThrowException($exception);
+
+        $this->spanScope->expects($this->once())
+            ->method('recordException')
+            ->with($exception);
+
+        $this->spanScope->expects($this->once())->method('end');
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('MongoDB error');
+
+        $aspect->process($this->proceedingJoinPoint);
+    }
+
+    public function testProcessWithDifferentCollectionName(): void
+    {
+        $ordersCollection = new \Hyperf\GoTask\MongoClient\Collection();
+        $reflection = new \ReflectionProperty(\Hyperf\GoTask\MongoClient\Collection::class, 'collection');
+        $reflection->setAccessible(true);
+        $reflection->setValue($ordersCollection, 'orders');
+
+        $proceedingJoinPoint = $this->createMock(ProceedingJoinPoint::class);
+        $proceedingJoinPoint->methodName = 'find';
+        $proceedingJoinPoint->method('getInstance')->willReturn($ordersCollection);
+
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $this->instrumentation
+            ->expects($this->once())
+            ->method('startSpan')
+            ->with(
+                $this->equalTo('mongodb FIND orders'),
+                $this->anything(),
+                $this->callback(function ($attributes) {
+                    return $attributes[DbAttributes::DB_COLLECTION_NAME] === 'orders';
+                })
+            )
+            ->willReturn($this->spanScope);
+
+        $proceedingJoinPoint->expects($this->once())
+            ->method('process')
+            ->willReturn([]);
+
+        $aspect->process($proceedingJoinPoint);
+    }
+
+    public function testFeatureName(): void
+    {
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $this->switcher
+        );
+
+        $reflection = new \ReflectionClass($aspect);
+        $method = $reflection->getMethod('featureName');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($aspect);
+
+        $this->assertEquals('db_query', $result);
+    }
+
+    public function testProcessWithTracingDisabled(): void
+    {
+        $switcher = $this->createMock(Switcher::class);
+        $switcher->method('isTracingEnabled')->willReturn(false);
+        $switcher->method('isMetricsEnabled')->willReturn(true);
+
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $switcher
+        );
+
+        $this->proceedingJoinPoint->methodName = 'find';
+
+        $this->instrumentation->expects($this->never())->method('startSpan');
+
+        $this->meter->expects($this->once())
+            ->method('createHistogram')
+            ->willReturn($this->histogram);
+
+        $this->proceedingJoinPoint->expects($this->once())
+            ->method('process')
+            ->willReturn([]);
+
+        $aspect->process($this->proceedingJoinPoint);
+    }
+
+    public function testProcessWithMetricsDisabled(): void
+    {
+        $switcher = $this->createMock(Switcher::class);
+        $switcher->method('isTracingEnabled')->willReturn(true);
+        $switcher->method('isMetricsEnabled')->willReturn(false);
+
+        $aspect = new MongoAspect(
+            $this->config,
+            $this->instrumentation,
+            $switcher
+        );
+
+        $this->proceedingJoinPoint->methodName = 'find';
+
+        $this->instrumentation->expects($this->once())
+            ->method('startSpan')
+            ->willReturn($this->spanScope);
+
+        $this->meter->expects($this->never())->method('createHistogram');
+
+        $this->proceedingJoinPoint->expects($this->once())
+            ->method('process')
+            ->willReturn([]);
+
+        $aspect->process($this->proceedingJoinPoint);
+    }
+}


### PR DESCRIPTION
## Description
This pull request introduces MongoDB telemetry support and enhances AWS SQS telemetry, along with several supporting changes and tests. The most significant updates are the addition of a new `MongoAspect` for instrumenting MongoDB operations, improvements to SQS queue name extraction, and expanded test coverage for both features.

**MongoDB Telemetry Integration:**

* Added a new `MongoAspect` class to instrument MongoDB operations via `Hyperf\GoTask\MongoClient\Collection`, providing tracing and metrics for database queries. This includes span creation, error handling, and metric recording.
* Registered `MongoAspect` in the application's aspect configuration in `ConfigProvider.php`, ensuring it is active in the OpenTelemetry pipeline.
* Added comprehensive unit tests for `MongoAspect`, covering telemetry enablement, ignored methods, error handling, and various MongoDB operations.

**AWS SQS Telemetry Enhancements:**

* Improved queue name extraction logic in `SqsClientAspect` to prioritize `QueueName` from input, falling back to extraction from `QueueUrl` if not present.
* Added a new test case to verify correct handling of the `QueueName` parameter in SQS telemetry.
* Updated operation type resolution in `SqsClientAspect` to include support for the `getqueueurl` operation.

**Dependency and Build Improvements:**

* Added the `php83-pecl-pcov` extension to the Dockerfile for improved code coverage in testing.
* Minor fix in the `Makefile` to ensure the correct execution of the test command.

These changes collectively improve observability for MongoDB and AWS SQS operations and enhance the reliability and maintainability of the codebase.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Performance/Refactor
- [ ] CI/CD/Chore

## Checklist
- [x] Title follows *Conventional Commits* (e.g., `feat: add SQS aspect`)
- [x] Tests added/updated
- [x] `composer test` passes locally
- [x] Documentation updated (README/Docs)
- [x] No breaking changes (or documented if any)
