### PR TITLE
feat: use CoroutineHandler instead CurlHandler for HTTP exporter

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -13,6 +13,9 @@ use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
 use OpenTelemetry\SDK\Resource\ResourceInfo;
 use Hyperf\OpenTelemetry\Factory\CachedInstrumentationFactory;
 use Hyperf\OpenTelemetry\Factory\OTelResourceFactory;
+use Hyperf\OpenTelemetry\Support\HyperfGuzzle;
+use OpenTelemetry\SDK\Common\Http\Psr\Client\Discovery;
+use OpenTelemetry\SDK\Common\Http\Psr\Client\Discovery\Guzzle;
 use OpenTelemetry\SDK\Trace\TracerProviderInterface;
 
 class ConfigProvider
@@ -23,6 +26,11 @@ class ConfigProvider
     public function __invoke(): array
     {
         defined('BASE_PATH') || define('BASE_PATH', '');
+
+        Discovery::setDiscoverers([
+            HyperfGuzzle::class,
+            Guzzle::class,
+        ]);
 
         return [
             'dependencies' => [

--- a/src/Support/HyperfGuzzle.php
+++ b/src/Support/HyperfGuzzle.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\OpenTelemetry\Support;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Guzzle\CoroutineHandler;
+use Hyperf\Guzzle\PoolHandler;
+use OpenTelemetry\SDK\Common\Http\Psr\Client\Discovery\DiscoveryInterface;
+use Psr\Http\Client\ClientInterface;
+
+class HyperfGuzzle implements DiscoveryInterface
+{
+    public function available(): bool
+    {
+        return class_exists(CoroutineHandler::class) && ApplicationContext::hasContainer();
+    }
+
+    public function create(mixed $options): ClientInterface
+    {
+        $options = is_array($options) ? $options : [];
+
+        return new Client(array_merge($options, [
+            'handler' => $this->createHandler(),
+        ]));
+    }
+
+    private function createHandler(): HandlerStack
+    {
+        /** @var ContainerInterface $container */
+        $container = ApplicationContext::getContainer();
+
+        $config = $container->get(ConfigInterface::class)->get('open-telemetry.otlp_http.pool', []);
+
+        if (empty($config)) {
+            return HandlerStack::create(new CoroutineHandler());
+        }
+
+        return HandlerStack::create($container->make(PoolHandler::class, ['option' => $config]));
+    }
+}

--- a/tests/Unit/Support/HyperfGuzzleTest.php
+++ b/tests/Unit/Support/HyperfGuzzleTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Contract\ConfigInterface;
+use Hyperf\Guzzle\ClientFactory;
+use Hyperf\Guzzle\CoroutineHandler;
+use Hyperf\Guzzle\PoolHandler;
+use Hyperf\OpenTelemetry\Support\HyperfGuzzle;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use ReflectionAttribute;
+use ReflectionProperty;
+
+/**
+ * @internal
+ */
+class HyperfGuzzleTest extends TestCase
+{
+    private ?ContainerInterface $container = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (ApplicationContext::hasContainer()) {
+            $this->container = ApplicationContext::getContainer();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        m::close();
+
+        if ($this->container !== null) {
+            ApplicationContext::setContainer($this->container);
+        }
+        parent::tearDown();
+    }
+
+    public function testAvailableReturnsTrueWhenCoroutineHandlerExistsAndContainerAvailable()
+    {
+        $container = m::mock(ContainerInterface::class);
+        ApplicationContext::setContainer($container);
+
+        $hyperfGuzzle = new HyperfGuzzle();
+        $this->assertTrue($hyperfGuzzle->available());
+    }
+
+    public function testCreateReturnsClientWithCoroutineHandlerWhenPoolConfigIsEmpty()
+    {
+        $container = m::mock(ContainerInterface::class);
+        $config = m::mock(ConfigInterface::class);
+
+        $config->shouldReceive('get')
+            ->with('open-telemetry.otlp_http.pool', [])
+            ->andReturn([]);
+
+        $container->shouldReceive('get')
+            ->with(ConfigInterface::class)
+            ->andReturn($config);
+
+        ApplicationContext::setContainer($container);
+
+        $hyperfGuzzle = new HyperfGuzzle();
+        $options = ['timeout' => 30];
+        $client = $hyperfGuzzle->create($options);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $clientConfig = $client->getConfig();
+
+        $this->assertIsArray($clientConfig);
+        $this->assertInstanceOf(HandlerStack::class, $clientConfig['handler']);
+
+        $property = new ReflectionProperty(HandlerStack::class, 'handler');
+
+        $this->assertInstanceOf(CoroutineHandler::class, $property->getValue($clientConfig['handler']));
+    }
+
+    public function testCreateReturnsClientWithPoolHandlerWhenPoolConfigIsProvided()
+    {
+        $container = m::mock(ContainerInterface::class);
+        $config = m::mock(ConfigInterface::class);
+        $poolHandler = m::mock(PoolHandler::class);
+
+        $poolConfig = [
+            'min_connections' => 1,
+            'max_connections' => 10,
+        ];
+
+        $config->shouldReceive('get')
+            ->with('open-telemetry.otlp_http.pool', [])
+            ->andReturn($poolConfig);
+
+        $container->shouldReceive('get')
+            ->with(ConfigInterface::class)
+            ->andReturn($config);
+
+        $container->shouldReceive('make')
+            ->with(PoolHandler::class, ['option' => $poolConfig])
+            ->andReturn($poolHandler);
+
+        ApplicationContext::setContainer($container);
+
+        $hyperfGuzzle = new HyperfGuzzle();
+        $options = ['timeout' => 30];
+        $client = $hyperfGuzzle->create($options);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        /** @var Client $client */
+        $clientConfig = $client->getConfig();
+
+        $this->assertIsArray($clientConfig);
+        $this->assertInstanceOf(HandlerStack::class, $clientConfig['handler']);
+
+        $property = new ReflectionProperty(HandlerStack::class, 'handler');
+
+        $this->assertInstanceOf(PoolHandler::class, $property->getValue($clientConfig['handler']));
+    }
+
+    public function testCreateMergesOptionsWithHandler()
+    {
+        $container = m::mock(ContainerInterface::class);
+        $config = m::mock(ConfigInterface::class);
+
+        $config->shouldReceive('get')
+            ->with('open-telemetry.otlp_http.pool', [])
+            ->andReturn([]);
+
+        $container->shouldReceive('get')
+            ->with(ConfigInterface::class)
+            ->andReturn($config);
+
+        ApplicationContext::setContainer($container);
+
+        $hyperfGuzzle = new HyperfGuzzle();
+        $options = [
+            'timeout' => 30,
+            'base_uri' => 'http://localhost',
+        ];
+
+        /** @var Client $client */
+        $client = $hyperfGuzzle->create($options);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        $config = $client->getConfig();
+        $this->assertEquals(30, $config['timeout']);
+        $this->assertEquals('http://localhost', $config['base_uri']);
+        $this->assertInstanceOf(HandlerStack::class, $config['handler']);
+    }
+
+    public function testCreateWithEmptyOptions()
+    {
+        $container = m::mock(ContainerInterface::class);
+        $config = m::mock(ConfigInterface::class);
+
+        $config->shouldReceive('get')
+            ->with('open-telemetry.otlp_http.pool', [])
+            ->andReturn([]);
+
+        $container->shouldReceive('get')
+            ->with(ConfigInterface::class)
+            ->andReturn($config);
+
+        ApplicationContext::setContainer($container);
+
+        $hyperfGuzzle = new HyperfGuzzle();
+
+        /** @var Client $client */
+        $client = $hyperfGuzzle->create(null);
+
+        $this->assertInstanceOf(Client::class, $client);
+
+        $clientConfig = $client->getConfig();
+
+        $this->assertIsArray($clientConfig);
+        $this->assertInstanceOf(HandlerStack::class, $clientConfig['handler']);
+
+        $property = new ReflectionProperty(HandlerStack::class, 'handler');
+
+        $this->assertInstanceOf(CoroutineHandler::class, $property->getValue($clientConfig['handler']));
+    }
+}


### PR DESCRIPTION
## Description
The `OtlpHttpTransportFactory` [[1]](https://github.com/open-telemetry/opentelemetry-php/blob/main/src/Contrib/Otlp/OtlpHttpTransportFactory.php#L32) uses the `PsrTransportFactory` [[2]](https://github.com/open-telemetry/opentelemetry-php/blob/main/src/SDK/Common/Export/Http/PsrTransportFactory.php#L49) which in turn uses `Discovery`[[3]](https://github.com/open-telemetry/opentelemetry-php/blob/main/src/SDK/Common/Http/Psr/Client/Discovery.php) to obtain a functional instance of `ClientInterface` to emit data via HTTP. Therefore, to inject the `Guzzle\Client` with the `CoroutineHandler`, it was necessary to inject `HyperfGuzzle` as a possible discovery.

**Why not use Listeners, for example: BootApplication?**
The `TracerProviderFactory` is executed during the reading of dependencies (`dependencies.php`) which is read before any event is emitted. Therefore, it is necessary to register the `Discovery` before this stage.

If the pool configuration is defined within the `open-telemetry.php` file, the `PoolHandler` will be used; otherwise, the `CoroutineHandler` will be used. Example:
```php
return [
/* traces, metrics, logs **/
   'otlp_http' => [
        'pool' => [
            'min_connections' => 3,
            'max_connections' => 30,
            'connect_timeout' => 0.1,
            'wait_timeout' => 0.1,
        ],
    ]
 ];
 ```

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Performance/Refactor
- [ ] CI/CD/Chore

## Checklist
- [x] Title follows *Conventional Commits* (e.g., `feat: add SQS aspect`)
- [x] Tests added/updated
- [x] `composer test` passes locally
- [x] Documentation updated (README/Docs)
- [x] No breaking changes (or documented if any)