### PR TITLE
Fix: Histrogram Buckets

### DIFF
--- a/src/Aspect/GuzzleClientAspect.php
+++ b/src/Aspect/GuzzleClientAspect.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Promise\PromiseInterface;
 use Hyperf\Di\Aop\ProceedingJoinPoint;
 use Hyperf\Di\Exception\Exception;
 use Hyperf\OpenTelemetry\Propagator\HeadersPropagator;
+use Hyperf\OpenTelemetry\Support\MetricBoundaries;
 use Hyperf\OpenTelemetry\Support\SpanScope;
 use Hyperf\OpenTelemetry\Support\Uri;
 use Hyperf\Stringable\Str;
@@ -126,10 +127,15 @@ class GuzzleClientAspect extends AbstractAspect
             }
 
             if ($this->isMetricsEnabled) {
-                $duration = (microtime(true) - $start) * 1000;
+                $durationInSeconds = microtime(true) - $start;
                 $this->instrumentation->meter()
-                    ->createHistogram('http.client.request.duration', 'ms')
-                    ->record($duration, [
+                    ->createHistogram(
+                        HttpMetrics::HTTP_CLIENT_REQUEST_DURATION,
+                        's',
+                        'Duration of HTTP client requests.',
+                        ['ExplicitBucketBoundaries' => MetricBoundaries::HTTP_DURATION]
+                    )
+                    ->record($durationInSeconds, [
                         ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),
                         HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
                         HttpAttributes::HTTP_RESPONSE_STATUS_CODE => $response->getStatusCode(),
@@ -153,11 +159,16 @@ class GuzzleClientAspect extends AbstractAspect
             }
 
             if ($this->isMetricsEnabled) {
-                $duration = (microtime(true) - $start) * 1000;
+                $durationInSeconds = microtime(true) - $start;
                 $this->instrumentation->meter()
-                    ->createHistogram(HttpMetrics::HTTP_CLIENT_REQUEST_DURATION, 'ms')
+                    ->createHistogram(
+                        HttpMetrics::HTTP_CLIENT_REQUEST_DURATION,
+                        's',
+                        'Duration of HTTP client requests.',
+                        ['ExplicitBucketBoundaries' => MetricBoundaries::HTTP_DURATION]
+                    )
                     ->record(
-                        $duration,
+                        $durationInSeconds,
                         [
                             ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),
                             HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),

--- a/src/Listener/DbQueryExecutedListener.php
+++ b/src/Listener/DbQueryExecutedListener.php
@@ -8,6 +8,7 @@ use Hyperf\Collection\Arr;
 use Hyperf\Database\Events\QueryExecuted;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\OpenTelemetry\Support\AbstractInstrumenter;
+use Hyperf\OpenTelemetry\Support\MetricBoundaries;
 use Hyperf\Stringable\Str;
 use OpenTelemetry\API\Trace\SpanKind;
 use OpenTelemetry\SemConv\Attributes\DbAttributes;
@@ -91,10 +92,17 @@ class DbQueryExecutedListener extends AbstractInstrumenter implements ListenerIn
                 ];
             }
 
+            $durationInSeconds = $event->time / 1000;
+
             $this->instrumentation->meter()
-                ->createHistogram(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+                ->createHistogram(
+                    DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                    's',
+                    'Duration of database client operations.',
+                    ['ExplicitBucketBoundaries' => MetricBoundaries::DB_DURATION]
+                )
                 ->record(
-                    $event->time,
+                    $durationInSeconds,
                     array_merge(
                         $metricErrors,
                         [

--- a/src/Middleware/MetricMiddleware.php
+++ b/src/Middleware/MetricMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyperf\OpenTelemetry\Middleware;
 
+use Hyperf\OpenTelemetry\Support\MetricBoundaries;
 use Hyperf\OpenTelemetry\Support\Uri;
 use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 use OpenTelemetry\SemConv\Attributes\HttpAttributes;
@@ -49,11 +50,16 @@ class MetricMiddleware extends AbstractMiddleware
 
             throw $exception;
         } finally {
-            $duration = (microtime(true) - $startTime) * 1000;
+            $durationInSeconds = microtime(true) - $startTime;
 
             $this->instrumentation->meter()
-                ->createHistogram(HttpMetrics::HTTP_SERVER_REQUEST_DURATION, 'ms')
-                ->record($duration, $attributes);
+                ->createHistogram(
+                    HttpMetrics::HTTP_SERVER_REQUEST_DURATION,
+                    's',
+                    'Duration of HTTP server requests.',
+                    ['ExplicitBucketBoundaries' => MetricBoundaries::HTTP_DURATION]
+                )
+                ->record($durationInSeconds, $attributes);
         }
     }
 

--- a/src/Support/MetricBoundaries.php
+++ b/src/Support/MetricBoundaries.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\OpenTelemetry\Support;
+
+/**
+ * Explicit bucket boundaries for OpenTelemetry histograms.
+ *
+ * These boundaries follow OpenTelemetry semantic conventions.
+ *
+ * @see https://opentelemetry.io/docs/specs/semconv/http/http-metrics/
+ * @see https://opentelemetry.io/docs/specs/semconv/db/database-metrics/
+ */
+final class MetricBoundaries
+{
+    /**
+     * Explicit bucket boundaries for HTTP duration histograms.
+     * Values are in seconds as per OpenTelemetry semantic conventions.
+     *
+     * Used for:
+     * - http.server.request.duration
+     * - http.client.request.duration
+     *
+     * @see https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpserverrequestduration
+     * @see https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#metric-httpclientrequestduration
+     */
+    public const HTTP_DURATION = [
+        0.005,
+        0.01,
+        0.025,
+        0.05,
+        0.075,
+        0.1,
+        0.25,
+        0.5,
+        0.75,
+        1,
+        2.5,
+        5,
+        7.5,
+        10,
+    ];
+
+    /**
+     * Explicit bucket boundaries for database operation duration histograms.
+     * Values are in seconds as per OpenTelemetry semantic conventions.
+     *
+     * Used for:
+     * - db.client.operation.duration
+     *
+     * @see https://opentelemetry.io/docs/specs/semconv/db/database-metrics/#metric-dbclientoperationduration
+     */
+    public const DB_DURATION = [
+        0.001,
+        0.005,
+        0.01,
+        0.05,
+        0.1,
+        0.5,
+        1,
+        5,
+        10,
+    ];
+}

--- a/tests/Unit/Aspect/Aws/DynamoDbClientAspectTest.php
+++ b/tests/Unit/Aspect/Aws/DynamoDbClientAspectTest.php
@@ -173,7 +173,14 @@ class DynamoDbClientAspectTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
@@ -220,7 +227,14 @@ class DynamoDbClientAspectTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())

--- a/tests/Unit/Aspect/GuzzleClientAspectTest.php
+++ b/tests/Unit/Aspect/GuzzleClientAspectTest.php
@@ -198,7 +198,14 @@ class GuzzleClientAspectTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with('http.client.request.duration', 'ms')
+            ->with(
+                'http.client.request.duration',
+                's',
+                'Duration of HTTP client requests.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 14)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
@@ -288,7 +295,14 @@ class GuzzleClientAspectTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with('http.client.request.duration', 'ms')
+            ->with(
+                'http.client.request.duration',
+                's',
+                'Duration of HTTP client requests.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 14)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
@@ -378,7 +392,14 @@ class GuzzleClientAspectTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with('http.client.request.duration', 'ms')
+            ->with(
+                'http.client.request.duration',
+                's',
+                'Duration of HTTP client requests.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 14)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
@@ -458,7 +479,14 @@ class GuzzleClientAspectTest extends TestCase
 
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with('http.client.request.duration', 'ms')
+            ->with(
+                'http.client.request.duration',
+                's',
+                'Duration of HTTP client requests.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 14)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())

--- a/tests/Unit/Aspect/MongoAspectTest.php
+++ b/tests/Unit/Aspect/MongoAspectTest.php
@@ -166,7 +166,14 @@ class MongoAspectTest extends TestCase
 
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
@@ -251,7 +258,14 @@ class MongoAspectTest extends TestCase
 
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())

--- a/tests/Unit/Aspect/RedisAspectTest.php
+++ b/tests/Unit/Aspect/RedisAspectTest.php
@@ -123,7 +123,14 @@ class RedisAspectTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
@@ -193,7 +200,14 @@ class RedisAspectTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())

--- a/tests/Unit/Listener/DbQueryExecutedListenerTest.php
+++ b/tests/Unit/Listener/DbQueryExecutedListenerTest.php
@@ -147,12 +147,19 @@ class DbQueryExecutedListenerTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
             ->method('record')
-            ->with(25.3, [
+            ->with(0.0253, [
                 DbAttributes::DB_SYSTEM_NAME => DbAttributes::DB_SYSTEM_NAME_VALUE_POSTGRESQL,
                 DbAttributes::DB_COLLECTION_NAME => 'users',
                 DbAttributes::DB_NAMESPACE => 'testdb',
@@ -212,12 +219,19 @@ class DbQueryExecutedListenerTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
             ->method('record')
-            ->with(25.3, [
+            ->with(0.0253, [
                 DbAttributes::DB_SYSTEM_NAME => DbAttributes::DB_SYSTEM_NAME_VALUE_MYSQL,
                 DbAttributes::DB_COLLECTION_NAME => 'users',
                 DbAttributes::DB_NAMESPACE => 'testdb',
@@ -261,13 +275,20 @@ class DbQueryExecutedListenerTest extends TestCase
         // Metric
         $this->meter->expects($this->once())
             ->method('createHistogram')
-            ->with(DbMetrics::DB_CLIENT_OPERATION_DURATION, 'ms')
+            ->with(
+                DbMetrics::DB_CLIENT_OPERATION_DURATION,
+                's',
+                'Duration of database client operations.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 9)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())
             ->method('record')
             ->with(
-                10.5,
+                0.0105,
                 $this->callback(function ($attributes) {
                     $this->assertArrayHasKey(ErrorAttributes::ERROR_TYPE, $attributes);
 

--- a/tests/Unit/Middleware/MetricMiddlewareTest.php
+++ b/tests/Unit/Middleware/MetricMiddlewareTest.php
@@ -81,7 +81,14 @@ class MetricMiddlewareTest extends TestCase
         $this->configureResponseMock(200);
 
         $this->meter->method('createHistogram')
-            ->with(HttpMetrics::HTTP_SERVER_REQUEST_DURATION, 'ms')
+            ->with(
+                HttpMetrics::HTTP_SERVER_REQUEST_DURATION,
+                's',
+                'Duration of HTTP server requests.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 14)
+            )
             ->willReturn($this->histogram);
 
         $expectedAttributes = [
@@ -114,7 +121,14 @@ class MetricMiddlewareTest extends TestCase
         $this->configureResponseMock(200);
 
         $this->meter->method('createHistogram')
-            ->with(HttpMetrics::HTTP_SERVER_REQUEST_DURATION, 'ms')
+            ->with(
+                HttpMetrics::HTTP_SERVER_REQUEST_DURATION,
+                's',
+                'Duration of HTTP server requests.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 14)
+            )
             ->willReturn($this->histogram);
 
         $expectedAttributes = [
@@ -198,7 +212,14 @@ class MetricMiddlewareTest extends TestCase
             ->willThrowException($exception);
 
         $this->meter->method('createHistogram')
-            ->with(HttpMetrics::HTTP_SERVER_REQUEST_DURATION, 'ms')
+            ->with(
+                HttpMetrics::HTTP_SERVER_REQUEST_DURATION,
+                's',
+                'Duration of HTTP server requests.',
+                $this->callback(fn (array $advisory) => isset($advisory['ExplicitBucketBoundaries'])
+                    && is_array($advisory['ExplicitBucketBoundaries'])
+                    && count($advisory['ExplicitBucketBoundaries']) === 14)
+            )
             ->willReturn($this->histogram);
 
         $this->histogram->expects($this->once())


### PR DESCRIPTION
## Description
**Problem**

  Histogram metrics for HTTP and database operations were not following OpenTelemetry semantic conventions:

   1. Wrong unit: Duration metrics were being reported in milliseconds (ms) instead of seconds (s) [[1]](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/#http-server)
   2. Missing bucket boundaries: Histograms were created without explicit bucket boundaries [[2]](https://opentelemetry.io/docs/specs/semconv/db/database-metrics/#metric-dbclientoperationduration)

  **Solution**

   - Changed all duration metrics to use seconds as the unit
   - Added ExplicitBucketBoundaries as recommended by the OpenTelemetry specification
   - Created a centralized MetricBoundaries class to avoid duplication


## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Performance/Refactor
- [ ] CI/CD/Chore

## Checklist
- [x] Title follows *Conventional Commits* (e.g., `feat: add SQS aspect`)
- [x] Tests added/updated
- [x] `composer test` passes locally
- [x] Documentation updated (README/Docs)
- [x] No breaking changes (or documented if any)
