### PR TITLE
fix: align HTTP and DB spans with OpenTelemetry Semantic Conventions

### DIFF
--- a/src/Aspect/GuzzleClientAspect.php
+++ b/src/Aspect/GuzzleClientAspect.php
@@ -172,7 +172,6 @@ class GuzzleClientAspect extends AbstractAspect
                         [
                             ServerAttributes::SERVER_ADDRESS => $request->getUri()->getHost(),
                             HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),
-                            HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 0,
                             ErrorAttributes::ERROR_TYPE => get_class($throwable),
                             UrlIncubatingAttributes::URL_TEMPLATE => Uri::sanitize(
                                 $request->getUri()->getPath(),

--- a/src/Aspect/RedisAspect.php
+++ b/src/Aspect/RedisAspect.php
@@ -9,7 +9,6 @@ use Hyperf\Di\Exception\Exception;
 use Hyperf\OpenTelemetry\Support\MetricBoundaries;
 use Hyperf\Stringable\Str;
 use OpenTelemetry\API\Trace\SpanKind;
-use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SemConv\Attributes\DbAttributes;
 use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 use OpenTelemetry\SemConv\Incubating\Attributes\DbIncubatingAttributes;
@@ -43,23 +42,18 @@ class RedisAspect extends AbstractAspect
 
         if ($this->isTracingEnabled) {
             $scope = $this->instrumentation->startSpan(
-                name: 'Redis ' . Str::upper($command),
+                name: Str::upper($command),
                 spanKind: SpanKind::KIND_CLIENT,
                 attributes: [
                     DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
                     DbAttributes::DB_OPERATION_NAME => Str::upper($command),
                     DbAttributes::DB_QUERY_TEXT => Str::limit($commandFull, 512),
-                    'db.system' => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
-                    'db.operation.pool' => Str::upper($command),
-                    'redis.pool' => $poolName,
                 ]
             );
         }
 
         try {
             $result = $proceedingJoinPoint->process();
-
-            $scope?->setStatus(StatusCode::STATUS_OK);
         } catch (Throwable $e) {
             $scope?->recordException($e);
 

--- a/src/Listener/DbQueryExecutedListener.php
+++ b/src/Listener/DbQueryExecutedListener.php
@@ -55,7 +55,7 @@ class DbQueryExecutedListener extends AbstractInstrumenter implements ListenerIn
         $operation = Str::upper(Str::before($event->sql, ' '));
         $table = $this->extractTableName($sql);
         $driver = $this->getDriverName($event);
-        $spanName = $table ? "{$driver} {$operation} {$table}" : "{$driver} {$operation}";
+        $spanName = $table ? "{$operation} {$table}" : $operation;
 
         if ($this->isTracingEnabled) {
             $scope = $this->instrumentation->startSpan(
@@ -67,11 +67,9 @@ class DbQueryExecutedListener extends AbstractInstrumenter implements ListenerIn
                     DbAttributes::DB_NAMESPACE => $event->connection->getDatabaseName(),
                     DbAttributes::DB_OPERATION_NAME => Str::upper($operation),
                     DbAttributes::DB_QUERY_TEXT => $sql,
+                    DbAttributes::DB_QUERY_SUMMARY => $table ? "{$operation} {$table}" : $operation,
                     ServerAttributes::SERVER_ADDRESS => $event->connection->getConfig('host'),
                     ServerAttributes::SERVER_PORT => $event->connection->getConfig('port'),
-                    'db.system' => $driver,
-                    'db.operation' => Str::upper($operation),
-                    'db.sql.table' => $table,
                 ],
                 startTimestamp: $this->calculateQueryStartTime($nowInNs, $event->time)
             );

--- a/src/Middleware/TraceMiddleware.php
+++ b/src/Middleware/TraceMiddleware.php
@@ -34,7 +34,7 @@ class TraceMiddleware extends AbstractMiddleware
         $context = $this->instrumentation->propagator()->extract($request->getHeaders());
 
         $scope = $this->instrumentation->startSpan(
-            name: Uri::sanitize($path, $this->config->get('open-telemetry.traces.uri_mask', [])),
+            name: $request->getMethod() . ' ' . Uri::sanitize($path, $this->config->get('open-telemetry.traces.uri_mask', [])),
             spanKind: SpanKind::KIND_SERVER,
             attributes: [
                 HttpAttributes::HTTP_REQUEST_METHOD => $request->getMethod(),

--- a/tests/Unit/Aspect/GuzzleClientAspectTest.php
+++ b/tests/Unit/Aspect/GuzzleClientAspectTest.php
@@ -497,7 +497,6 @@ class GuzzleClientAspectTest extends TestCase
                     ServerAttributes::SERVER_ADDRESS => 'api.example.com',
                     UrlIncubatingAttributes::URL_TEMPLATE => '/v1/users',
                     HttpAttributes::HTTP_REQUEST_METHOD => 'POST',
-                    HttpAttributes::HTTP_RESPONSE_STATUS_CODE => 0,
                     ErrorAttributes::ERROR_TYPE => $exception::class,
                 ]
             );

--- a/tests/Unit/Aspect/RedisAspectTest.php
+++ b/tests/Unit/Aspect/RedisAspectTest.php
@@ -14,7 +14,6 @@ use Hyperf\OpenTelemetry\Switcher;
 use OpenTelemetry\API\Metrics\HistogramInterface;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Trace\SpanKind;
-use OpenTelemetry\API\Trace\StatusCode;
 use OpenTelemetry\SemConv\Attributes\DbAttributes;
 use OpenTelemetry\SemConv\Attributes\ErrorAttributes;
 use OpenTelemetry\SemConv\Incubating\Attributes\DbIncubatingAttributes;
@@ -101,22 +100,15 @@ class RedisAspectTest extends TestCase
             ->expects($this->once())
             ->method('startSpan')
             ->with(
-                $this->equalTo('Redis GET'),
+                $this->equalTo('GET'),
                 $this->equalTo(SpanKind::KIND_CLIENT),
                 [
                     DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
                     DbAttributes::DB_OPERATION_NAME => 'GET',
                     DbAttributes::DB_QUERY_TEXT => 'get user:123',
-                    'db.system' => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
-                    'db.operation.pool' => 'GET',
-                    'redis.pool' => 'default',
                 ]
             )
             ->willReturn($this->spanScope);
-
-        $this->spanScope->expects($this->once())
-            ->method('setStatus')
-            ->with(StatusCode::STATUS_OK);
 
         $this->spanScope->expects($this->once())->method('end');
 
@@ -178,15 +170,12 @@ class RedisAspectTest extends TestCase
             ->expects($this->once())
             ->method('startSpan')
             ->with(
-                $this->equalTo('Redis SET'),
+                $this->equalTo('SET'),
                 $this->equalTo(SpanKind::KIND_CLIENT),
                 [
                     DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
                     DbAttributes::DB_OPERATION_NAME => 'SET',
                     DbAttributes::DB_QUERY_TEXT => 'set user:123 data EX 3600',
-                    'db.system' => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
-                    'db.operation.pool' => 'SET',
-                    'redis.pool' => 'semaphore',
                 ]
             )
             ->willReturn($this->spanScope);
@@ -257,15 +246,12 @@ class RedisAspectTest extends TestCase
             ->expects($this->once())
             ->method('startSpan')
             ->with(
-                $this->equalTo('Redis HMSET'),
+                $this->equalTo('HMSET'),
                 $this->equalTo(SpanKind::KIND_CLIENT),
                 [
                     DbAttributes::DB_SYSTEM_NAME => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
                     DbAttributes::DB_OPERATION_NAME => 'HMSET',
                     DbAttributes::DB_QUERY_TEXT => 'hmset user:123 John 30 São Paulo',
-                    'db.system' => DbIncubatingAttributes::DB_SYSTEM_NAME_VALUE_REDIS,
-                    'redis.pool' => 'default',
-                    'db.operation.pool' => 'HMSET',
                 ]
             )
             ->willReturn($this->spanScope);

--- a/tests/Unit/Listener/DbQueryExecutedListenerTest.php
+++ b/tests/Unit/Listener/DbQueryExecutedListenerTest.php
@@ -124,7 +124,7 @@ class DbQueryExecutedListenerTest extends TestCase
             ->expects($this->once())
             ->method('startSpan')
             ->with(
-                $this->equalTo('postgresql SELECT users'),
+                $this->equalTo('SELECT users'),
                 $this->equalTo(SpanKind::KIND_CLIENT),
                 [
                     DbAttributes::DB_SYSTEM_NAME => DbAttributes::DB_SYSTEM_NAME_VALUE_POSTGRESQL,
@@ -132,11 +132,9 @@ class DbQueryExecutedListenerTest extends TestCase
                     DbAttributes::DB_NAMESPACE => 'testdb',
                     DbAttributes::DB_OPERATION_NAME => 'SELECT',
                     DbAttributes::DB_QUERY_TEXT => $sql,
+                    DbAttributes::DB_QUERY_SUMMARY => 'SELECT users',
                     ServerAttributes::SERVER_ADDRESS => 'localhost',
                     ServerAttributes::SERVER_PORT => 8000,
-                    'db.system' => DbAttributes::DB_SYSTEM_NAME_VALUE_POSTGRESQL,
-                    'db.operation' => 'SELECT',
-                    'db.sql.table' => 'users',
                 ],
                 $this->isType('int')
             )
@@ -196,7 +194,7 @@ class DbQueryExecutedListenerTest extends TestCase
             ->expects($this->once())
             ->method('startSpan')
             ->with(
-                $this->equalTo('mysql SELECT users'),
+                $this->equalTo('SELECT users'),
                 $this->equalTo(SpanKind::KIND_CLIENT),
                 [
                     DbAttributes::DB_SYSTEM_NAME => DbAttributes::DB_SYSTEM_NAME_VALUE_MYSQL,
@@ -204,11 +202,9 @@ class DbQueryExecutedListenerTest extends TestCase
                     DbAttributes::DB_NAMESPACE => 'testdb',
                     DbAttributes::DB_OPERATION_NAME => 'SELECT',
                     DbAttributes::DB_QUERY_TEXT => 'SELECT id, name FROM users WHERE active = \'1\'',
+                    DbAttributes::DB_QUERY_SUMMARY => 'SELECT users',
                     ServerAttributes::SERVER_ADDRESS => 'localhost',
                     ServerAttributes::SERVER_PORT => 8000,
-                    'db.system' => DbAttributes::DB_SYSTEM_NAME_VALUE_MYSQL,
-                    'db.operation' => 'SELECT',
-                    'db.sql.table' => 'users',
                 ],
                 $this->isType('int')
             )
@@ -265,7 +261,7 @@ class DbQueryExecutedListenerTest extends TestCase
             ->expects($this->once())
             ->method('startSpan')
             ->with(
-                $this->equalTo('microsoft.sql_server SELECT users')
+                $this->equalTo('SELECT users')
             )
             ->willReturn($spanScope);
 

--- a/tests/Unit/Middleware/TraceMiddlewareTest.php
+++ b/tests/Unit/Middleware/TraceMiddlewareTest.php
@@ -141,7 +141,7 @@ class TraceMiddlewareTest extends TestCase
         $this->instrumentation->expects($this->once())
             ->method('startSpan')
             ->with(
-                '/users/{number}',
+                'GET /users/{number}',
                 SpanKind::KIND_SERVER,
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',
@@ -204,7 +204,7 @@ class TraceMiddlewareTest extends TestCase
         $this->instrumentation->expects($this->once())
             ->method('startSpan')
             ->with(
-                '/users/{identifier}',
+                'GET /users/{identifier}',
                 SpanKind::KIND_SERVER,
                 [
                     HttpAttributes::HTTP_REQUEST_METHOD => 'GET',


### PR DESCRIPTION
## Description

  This PR fixes span naming, attributes, and status code handling across HTTP (server/client) and database (SQL, Redis, MongoDB) instrumentation to conform with the OpenTelemetry Semantic Conventions.

  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

  HTTP Spans

  TraceMiddleware (server spans)

   - Fixed span name to follow the {method} {target} format (e.g. GET /users/{number}) as required by the spec. Previously, only the sanitized path was used.

  GuzzleClientAspect (client spans)

   - Removed http.response.status_code = 0 from metric attributes on rejected requests (network errors, timeouts). Per spec, this attribute is conditionally required: if and only if a response was received. When no response exists,
  the attribute must be omitted.

  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

  Database Spans

  DbQueryExecutedListener (MySQL / PostgreSQL)

   - Fixed span name: removed the driver prefix (e.g. mysql, postgresql). Span name now follows {operation} {table} (e.g. SELECT users).
   - Added db.query.summary to span attributes (was previously only set on metrics).
   - Removed deprecated legacy attributes: db.system, db.operation, db.sql.table.

  RedisAspect

   - Fixed span name: removed the Redis  prefix. Span name is now the command only (e.g. GET, HMSET).
   - Removed setStatus(STATUS_OK) on successful operations — per spec, span status SHOULD be left UNSET on success.
   - Removed deprecated legacy attributes: db.system, db.operation.pool, redis.pool.

  MongoAspect

   - Fixed span name: removed the mongodb prefix and fixed casing. Span name now uses the method name as-is (e.g. find users, insertOne users), matching MongoDB's camelCase command naming convention.
   - Added db.namespace (database name) via reflection, as it is conditionally required for MongoDB spans.
   - Removed setStatus(STATUS_OK) on successful operations.
   - Removed deprecated legacy attributes: db.system, db.operation, db.collection.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Performance/Refactor
- [ ] CI/CD/Chore

## Checklist
- [x] Title follows *Conventional Commits* (e.g., `feat: add SQS aspect`)
- [x] Tests added/updated
- [x] `composer test` passes locally
- [x] Documentation updated (README/Docs)
- [x] No breaking changes (or documented if any)
