### PR TITLE
Fix/shutdown

### DIFF
--- a/src/Factory/SDKBuilder.php
+++ b/src/Factory/SDKBuilder.php
@@ -35,7 +35,7 @@ class SDKBuilder
             ->setMeterProvider($meterProvider)
             ->setLoggerProvider($loggerProvider)
             ->setPropagator(TraceContextPropagator::getInstance())
-            ->setAutoShutdown(true)
+            ->setAutoShutdown(false)
             ->buildAndRegisterGlobal();
     }
 }

--- a/src/Listener/OtelShutdownListener.php
+++ b/src/Listener/OtelShutdownListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Hyperf\OpenTelemetry\Listener;
 
 use Hyperf\Contract\StdoutLoggerInterface;
+use Hyperf\Coroutine\Coroutine;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\OnWorkerExit;
 use OpenTelemetry\SDK\Metrics\MeterProviderInterface;
@@ -29,16 +30,18 @@ class OtelShutdownListener implements ListenerInterface
 
     public function process(object $event): void
     {
-        try {
-            $this->tracerProvider->shutdown();
-        } catch (Throwable $e) {
-            $this->logger->warning(sprintf('[OTel] tracer shutdown failed: %s', $e->getMessage()));
-        }
+        Coroutine::create(function () {
+            try {
+                $this->tracerProvider->shutdown();
+            } catch (Throwable $e) {
+                $this->logger->warning(sprintf('[OTel] tracer shutdown failed: %s', $e->getMessage()));
+            }
 
-        try {
-            $this->meterProvider->shutdown();
-        } catch (Throwable $e) {
-            $this->logger->warning(sprintf('[OTel] meter shutdown failed: %s', $e->getMessage()));
-        }
+            try {
+                $this->meterProvider->shutdown();
+            } catch (Throwable $e) {
+                $this->logger->warning(sprintf('[OTel] meter shutdown failed: %s', $e->getMessage()));
+            }
+        });
     }
 }

--- a/src/Support/Uri.php
+++ b/src/Support/Uri.php
@@ -8,7 +8,7 @@ class Uri
 {
     public static function sanitize(string $uri, array $uriMask = []): string
     {
-        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?=\/|$)/i';
+        $uuid = '/\/(?<=\/)([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})(?=\/|$)/i';
 
         $defaultPatterns = [
             $uuid => '/{uuid}',

--- a/src/Transport/SwooleGrpcTransportFactory.php
+++ b/src/Transport/SwooleGrpcTransportFactory.php
@@ -37,6 +37,9 @@ final class SwooleGrpcTransportFactory implements TransportFactoryInterface
         if ($compression !== null) {
             $compressionType = is_array($compression) ? ($compression[0] ?? null) : $compression;
         }
+        if ($compressionType === 'none') {
+            $compressionType = null;
+        }
 
         return new SwooleGrpcTransport(
             host: $parsed['host'],

--- a/tests/Unit/Listener/OtelShutdownListenerTest.php
+++ b/tests/Unit/Listener/OtelShutdownListenerTest.php
@@ -29,28 +29,51 @@ class OtelShutdownListenerTest extends TestCase
         $this->assertInstanceOf(ListenerInterface::class, $listener);
     }
 
-    public function testProcessCallsShutdown(): void
+    public function testListensToOnWorkerExit(): void
+    {
+        $listener = new OtelShutdownListener(
+            $this->createMock(MeterProviderInterface::class),
+            $this->createMock(TracerProviderInterface::class),
+            $this->createMock(StdoutLoggerInterface::class)
+        );
+        $this->assertSame([OnWorkerExit::class], $listener->listen());
+    }
+
+    public function testProcessCallsShutdownInsideCoroutine(): void
     {
         $meterProvider = $this->createMock(MeterProviderInterface::class);
         $tracerProvider = $this->createMock(TracerProviderInterface::class);
         $logger = $this->createMock(StdoutLoggerInterface::class);
 
-        $meterProvider->expects($this->once())->method('shutdown');
         $tracerProvider->expects($this->once())->method('shutdown');
+        $meterProvider->expects($this->once())->method('shutdown');
         $logger->expects($this->never())->method('warning');
 
         $listener = new OtelShutdownListener($meterProvider, $tracerProvider, $logger);
         $listener->process(new OnWorkerExit($this->createMock(Server::class), 0));
     }
 
-    public function testProcessLogsWarningOnException(): void
+    public function testProcessLogsWarningOnTracerException(): void
+    {
+        $meterProvider = $this->createMock(MeterProviderInterface::class);
+        $tracerProvider = $this->createMock(TracerProviderInterface::class);
+        $logger = $this->createMock(StdoutLoggerInterface::class);
+
+        $tracerProvider->method('shutdown')->willThrowException(new RuntimeException('tracer error'));
+        $logger->expects($this->atLeastOnce())->method('warning')->with($this->stringContains('tracer'));
+
+        $listener = new OtelShutdownListener($meterProvider, $tracerProvider, $logger);
+        $listener->process(new OnWorkerExit($this->createMock(Server::class), 0));
+    }
+
+    public function testProcessLogsWarningOnMeterException(): void
     {
         $meterProvider = $this->createMock(MeterProviderInterface::class);
         $tracerProvider = $this->createMock(TracerProviderInterface::class);
         $logger = $this->createMock(StdoutLoggerInterface::class);
 
         $meterProvider->method('shutdown')->willThrowException(new RuntimeException('meter error'));
-        $logger->expects($this->once())->method('warning')->with($this->stringContains('meter error'));
+        $logger->expects($this->atLeastOnce())->method('warning')->with($this->stringContains('meter'));
 
         $listener = new OtelShutdownListener($meterProvider, $tracerProvider, $logger);
         $listener->process(new OnWorkerExit($this->createMock(Server::class), 0));

--- a/tests/Unit/Support/UriTest.php
+++ b/tests/Unit/Support/UriTest.php
@@ -33,6 +33,13 @@ class UriTest extends TestCase
         $this->assertStringContainsString('/{uuid}', $result);
     }
 
+    public function testSanitizeUuidV7()
+    {
+        $uri = '/019363e0-7be6-7f00-8a7d-d6fb379a33a1/';
+        $result = Uri::sanitize($uri);
+        $this->assertStringContainsString('/{uuid}', $result);
+    }
+
     public function testSanitizeLicensePlate()
     {
         $uri = '/ABC1A23/';

--- a/tests/Unit/Transport/SwooleGrpcTransportFactoryTest.php
+++ b/tests/Unit/Transport/SwooleGrpcTransportFactoryTest.php
@@ -100,4 +100,22 @@ class SwooleGrpcTransportFactoryTest extends TestCase
 
         $this->assertSame(ContentTypes::PROTOBUF, $transport->contentType());
     }
+
+    public function testCreateWithCompressionNoneTreatedAsNull(): void
+    {
+        $factory = new SwooleGrpcTransportFactory();
+
+        $transport = $factory->create(
+            endpoint: 'http://localhost:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export',
+            contentType: ContentTypes::PROTOBUF,
+            compression: 'none',
+        );
+
+        $this->assertSame(ContentTypes::PROTOBUF, $transport->contentType());
+
+        // Use reflection to verify compression was normalized to null
+        $reflection = new \ReflectionClass($transport);
+        $compressionProp = $reflection->getProperty('compression');
+        $this->assertNull($compressionProp->getValue($transport));
+    }
 }


### PR DESCRIPTION
## Description

**UUID v7 URI Masking**

The UUID regex in `Uri::sanitize()` used [1-5] for the version nibble, which excluded UUID v6, v7, and v8 defined in RFC 9562. UUID v7 (time-ordered) is increasingly adopted and was not being maskedin span names.

Fix: Expanded version nibble from [1-5] to [1-8]. The variant byte constraint [89ab] is preserved to prevent false positives.

**gRPC Compression 'none' Handling**

The vendor `OtlpHttpTransportFactory` normalizes `compression = 'none'` to `null`, but `SwooleGrpcTransportFactory` did not. When `'none'` was passed as compression, `packMessage()` would set the gRPC
compressed flag to 1 (because `$compression !== null`) without applying actual compression — producing a malformed gRPC frame rejected by collectors.

Fix: Added the same `'none'` → null normalization in `SwooleGrpcTransportFactory`, mirroring the vendor HTTP transport behavior.

**Swoole Coroutine Error on Worker Shutdown**

During pod shutdown (deploy, restart, `max_request` reached), `TracerProvider->shutdown()` and `MeterProvider->shutdown()` were called outside of a coroutine context, causing `Swoole\Error: API must be called in the coroutine`.

Two sources of the error were identified:

 - `setAutoShutdown(true)` in SDKBuilder registered PHP's `register_shutdown_function`(), which runs after Swoole's event loop has ended (no coroutine context).
 - `OtelShutdownListener` on `OnWorkerExit` — Hyperf's `WorkerExitCallback::onWorkerExit()` dispatches the event synchronously before creating a coroutine, so the listener ran outside coroutine context.

Fix:

 - Disabled setAutoShutdown (PHP shutdown functions are incompatible with Swoole's coroutine model)
 - Wrapped `OtelShutdownListener::process()` in `Coroutine::create()`, following the same pattern used by Hyperf's own `WorkerExitCallback`

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Performance/Refactor
- [ ] CI/CD/Chore

## Checklist
- [x] Title follows *Conventional Commits* (e.g., `feat: add SQS aspect`)
- [x] Tests added/updated
- [x] `composer test` passes locally
- [x] Documentation updated (README/Docs)
- [x] No breaking changes (or documented if any)
