### PR TITLE
fix: reset dead gRPC client on transport failure and retry once on send

### DIFF
--- a/src/Transport/SwooleGrpcTransport.php
+++ b/src/Transport/SwooleGrpcTransport.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Hyperf\OpenTelemetry\Transport;
 
+use Closure;
 use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Common\Export\TransportInterface;
@@ -33,6 +34,7 @@ final class SwooleGrpcTransport implements TransportInterface
         private readonly float $timeout = 10.0,
         private readonly bool $ssl = false,
         private readonly ?string $compression = null,
+        private readonly ?Closure $clientFactory = null,
     ) {
     }
 
@@ -91,7 +93,7 @@ final class SwooleGrpcTransport implements TransportInterface
             return new CompletedFuture(null);
         }
 
-        return new ErrorFuture($lastError ?? new RuntimeException('Failed to send gRPC request'));
+        return new ErrorFuture($lastError);
     }
 
     public function shutdown(?CancellationInterface $cancellation = null): bool
@@ -124,7 +126,9 @@ final class SwooleGrpcTransport implements TransportInterface
     private function getClient(): Client
     {
         if ($this->client === null || ! $this->client->connected) {
-            $this->client = new Client($this->host, $this->port, $this->ssl);
+            $factory = $this->clientFactory
+                ?? static fn (string $h, int $p, bool $s): Client => new Client($h, $p, $s);
+            $this->client = $factory($this->host, $this->port, $this->ssl);
             $this->client->set([
                 'timeout' => $this->timeout,
             ]);

--- a/src/Transport/SwooleGrpcTransport.php
+++ b/src/Transport/SwooleGrpcTransport.php
@@ -47,28 +47,36 @@ final class SwooleGrpcTransport implements TransportInterface
             return new ErrorFuture(new RuntimeException('Transport is closed'));
         }
 
-        try {
-            $client = $this->getClient();
+        $request = new Request();
+        $request->method = 'POST';
+        $request->path = $this->method;
+        $request->headers = $this->buildHeaders();
+        $request->data = $this->packMessage($this->compress($payload));
 
-            $data = $this->compress($payload);
+        $lastError = null;
+        for ($attempt = 0; $attempt < 2; ++$attempt) {
+            try {
+                $client = $this->getClient();
+                $streamId = $client->send($request);
 
-            $request = new Request();
-            $request->method = 'POST';
-            $request->path = $this->method;
-            $request->headers = $this->buildHeaders();
-            $request->data = $this->packMessage($data);
-
-            $streamId = $client->send($request);
-
-            if ($streamId === false || $streamId <= 0) {
-                return new ErrorFuture(new RuntimeException(
-                    'Failed to send gRPC request: ' . ($client->errMsg ?: 'unknown error')
-                ));
+                if ($streamId === false || $streamId <= 0) {
+                    $lastError = new RuntimeException(
+                        'Failed to send gRPC request: ' . ($client->errMsg ?: 'unknown error')
+                    );
+                    $this->resetClient();
+                    continue;
+                }
+            } catch (Throwable $e) {
+                $lastError = $e;
+                $this->resetClient();
+                continue;
             }
 
+            // Past this point the stream is established — do not retry to avoid duplicate exports.
             $response = $client->recv($this->timeout);
 
             if ($response === false) {
+                $this->resetClient();
                 return new ErrorFuture(new RuntimeException(
                     'Failed to receive gRPC response: ' . ($client->errMsg ?: 'timeout')
                 ));
@@ -81,9 +89,9 @@ final class SwooleGrpcTransport implements TransportInterface
             }
 
             return new CompletedFuture(null);
-        } catch (Throwable $e) {
-            return new ErrorFuture($e);
         }
+
+        return new ErrorFuture($lastError ?? new RuntimeException('Failed to send gRPC request'));
     }
 
     public function shutdown(?CancellationInterface $cancellation = null): bool
@@ -105,6 +113,12 @@ final class SwooleGrpcTransport implements TransportInterface
     public function forceFlush(?CancellationInterface $cancellation = null): bool
     {
         return ! $this->closed;
+    }
+
+    private function resetClient(): void
+    {
+        $this->client?->close();
+        $this->client = null;
     }
 
     private function getClient(): Client

--- a/tests/Unit/Transport/SwooleGrpcTransportTest.php
+++ b/tests/Unit/Transport/SwooleGrpcTransportTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Transport;
 
+use Closure;
 use Hyperf\OpenTelemetry\Transport\SwooleGrpcTransport;
 use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use RuntimeException;
 use Swoole\Coroutine\Http2\Client;
+use Swoole\Http2\Response;
 
 /**
  * @internal
@@ -68,20 +70,56 @@ class SwooleGrpcTransportTest extends TestCase
 
     public function testSendResetsClientWhenStreamIdIsFalse(): void
     {
-        $transport = $this->makeTransport(timeout: 0.05);
+        $stale = $this->mockClient();
+        $stale->errMsg = 'broken pipe';
+        $stale->method('send')->willReturn(false);
+        $stale->method('close')->willReturn(true);
 
-        $mock = $this->mockConnectedClient();
-        $mock->errMsg = 'broken pipe';
-        $mock->method('send')->willReturn(false);
-        $mock->method('close')->willReturn(true);
+        // Second attempt also fails — deterministic, no real network call.
+        $second = $this->mockClient();
+        $second->errMsg = 'broken pipe';
+        $second->method('send')->willReturn(false);
+        $second->method('close')->willReturn(true);
 
-        $reflection = $this->injectClient($transport, $mock);
+        $calls = 0;
+        $transport = $this->makeTransport(
+            timeout: 0.05,
+            clientFactory: function () use ($stale, $second, &$calls): Client {
+                return $calls++ === 0 ? $stale : $second;
+            }
+        );
 
         $future = $transport->send('test payload');
 
+        $reflection = new ReflectionClass($transport);
         $this->assertNull($reflection->getProperty('client')->getValue($transport));
         $this->expectException(RuntimeException::class);
         $future->await();
+    }
+
+    public function testSendRetriesAndSucceedsAfterInitialSendFailure(): void
+    {
+        $stale = $this->mockClient();
+        $stale->errMsg = 'broken pipe';
+        $stale->method('send')->willReturn(false);
+        $stale->method('close')->willReturn(true);
+
+        $response = new Response();
+        $response->headers = ['grpc-status' => '0'];
+
+        $fresh = $this->mockClient();
+        $fresh->method('send')->willReturn(1);
+        $fresh->method('recv')->willReturn($response);
+
+        $calls = 0;
+        $transport = $this->makeTransport(
+            clientFactory: function () use ($stale, $fresh, &$calls): Client {
+                return $calls++ === 0 ? $stale : $fresh;
+            }
+        );
+
+        $future = $transport->send('test payload');
+        $this->assertNull($future->await());
     }
 
     public function testSendResetsClientWhenRecvReturnsFalse(): void
@@ -118,13 +156,14 @@ class SwooleGrpcTransportTest extends TestCase
         $transport->send('test payload');
     }
 
-    private function makeTransport(float $timeout = 10.0): SwooleGrpcTransport
+    private function makeTransport(float $timeout = 10.0, ?Closure $clientFactory = null): SwooleGrpcTransport
     {
         return new SwooleGrpcTransport(
             host: 'localhost',
             port: 4317,
             method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
             timeout: $timeout,
+            clientFactory: $clientFactory,
         );
     }
 
@@ -133,6 +172,18 @@ class SwooleGrpcTransportTest extends TestCase
         $reflection = new ReflectionClass($transport);
         $reflection->getProperty('client')->setValue($transport, $client);
         return $reflection;
+    }
+
+    private function mockClient(bool $connectSucceeds = true): Client
+    {
+        $mock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mock->connected = false;
+        $mock->errMsg = '';
+        $mock->method('set')->willReturn(true);
+        $mock->method('connect')->willReturn($connectSucceeds);
+        return $mock;
     }
 
     private function mockConnectedClient(): Client

--- a/tests/Unit/Transport/SwooleGrpcTransportTest.php
+++ b/tests/Unit/Transport/SwooleGrpcTransportTest.php
@@ -7,7 +7,9 @@ namespace Tests\Unit\Transport;
 use Hyperf\OpenTelemetry\Transport\SwooleGrpcTransport;
 use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use RuntimeException;
+use Swoole\Coroutine\Http2\Client;
 
 /**
  * @internal
@@ -16,33 +18,21 @@ class SwooleGrpcTransportTest extends TestCase
 {
     public function testContentTypeReturnsProtobuf(): void
     {
-        $transport = new SwooleGrpcTransport(
-            host: 'localhost',
-            port: 4317,
-            method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
-        );
+        $transport = $this->makeTransport();
 
         $this->assertSame(ContentTypes::PROTOBUF, $transport->contentType());
     }
 
     public function testShutdownReturnsTrueOnFirstCall(): void
     {
-        $transport = new SwooleGrpcTransport(
-            host: 'localhost',
-            port: 4317,
-            method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
-        );
+        $transport = $this->makeTransport();
 
         $this->assertTrue($transport->shutdown());
     }
 
     public function testShutdownReturnsFalseOnSecondCall(): void
     {
-        $transport = new SwooleGrpcTransport(
-            host: 'localhost',
-            port: 4317,
-            method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
-        );
+        $transport = $this->makeTransport();
 
         $transport->shutdown();
         $this->assertFalse($transport->shutdown());
@@ -50,22 +40,14 @@ class SwooleGrpcTransportTest extends TestCase
 
     public function testForceFlushReturnsTrueWhenNotClosed(): void
     {
-        $transport = new SwooleGrpcTransport(
-            host: 'localhost',
-            port: 4317,
-            method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
-        );
+        $transport = $this->makeTransport();
 
         $this->assertTrue($transport->forceFlush());
     }
 
     public function testForceFlushReturnsFalseWhenClosed(): void
     {
-        $transport = new SwooleGrpcTransport(
-            host: 'localhost',
-            port: 4317,
-            method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
-        );
+        $transport = $this->makeTransport();
 
         $transport->shutdown();
         $this->assertFalse($transport->forceFlush());
@@ -73,11 +55,7 @@ class SwooleGrpcTransportTest extends TestCase
 
     public function testSendReturnsErrorFutureWhenClosed(): void
     {
-        $transport = new SwooleGrpcTransport(
-            host: 'localhost',
-            port: 4317,
-            method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
-        );
+        $transport = $this->makeTransport();
 
         $transport->shutdown();
 
@@ -86,5 +64,84 @@ class SwooleGrpcTransportTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Transport is closed');
         $future->await();
+    }
+
+    public function testSendResetsClientWhenStreamIdIsFalse(): void
+    {
+        $transport = $this->makeTransport(timeout: 0.05);
+
+        $mock = $this->mockConnectedClient();
+        $mock->errMsg = 'broken pipe';
+        $mock->method('send')->willReturn(false);
+        $mock->method('close')->willReturn(true);
+
+        $reflection = $this->injectClient($transport, $mock);
+
+        $future = $transport->send('test payload');
+
+        $this->assertNull($reflection->getProperty('client')->getValue($transport));
+        $this->expectException(RuntimeException::class);
+        $future->await();
+    }
+
+    public function testSendResetsClientWhenRecvReturnsFalse(): void
+    {
+        $transport = $this->makeTransport(timeout: 0.05);
+
+        $mock = $this->mockConnectedClient();
+        $mock->errMsg = 'timeout';
+        $mock->method('send')->willReturn(1);
+        $mock->method('recv')->willReturn(false);
+        $mock->method('close')->willReturn(true);
+
+        $reflection = $this->injectClient($transport, $mock);
+
+        $future = $transport->send('test payload');
+
+        $this->assertNull($reflection->getProperty('client')->getValue($transport));
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Failed to receive gRPC response');
+        $future->await();
+    }
+
+    public function testSendDoesNotRetryAfterRecvFailure(): void
+    {
+        $transport = $this->makeTransport(timeout: 0.05);
+
+        $mock = $this->mockConnectedClient();
+        $mock->method('send')->willReturn(1);
+        $mock->expects($this->once())->method('recv')->willReturn(false);
+        $mock->method('close')->willReturn(true);
+
+        $this->injectClient($transport, $mock);
+
+        $transport->send('test payload');
+    }
+
+    private function makeTransport(float $timeout = 10.0): SwooleGrpcTransport
+    {
+        return new SwooleGrpcTransport(
+            host: 'localhost',
+            port: 4317,
+            method: '/opentelemetry.proto.collector.trace.v1.TraceService/Export',
+            timeout: $timeout,
+        );
+    }
+
+    private function injectClient(SwooleGrpcTransport $transport, Client $client): ReflectionClass
+    {
+        $reflection = new ReflectionClass($transport);
+        $reflection->getProperty('client')->setValue($transport, $client);
+        return $reflection;
+    }
+
+    private function mockConnectedClient(): Client
+    {
+        $mock = $this->getMockBuilder(Client::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mock->connected = true;
+        $mock->errMsg = '';
+        return $mock;
     }
 }


### PR DESCRIPTION
## Problem (closes #23 — Bug 1)

When the OTLP collector closes an HTTP/2 connection (GOAWAY, TCP FIN, rolling restart), `Swoole\Coroutine\Http2\Client::$connected` stays `true` — so `getClient()` kept returning the stale instance. Every subsequent export failed with *"Broken pipe"* until the worker was restarted.

## Solution

### `SwooleGrpcTransport::send()`

- Wrap `getClient()` + `client->send()` in a **retry loop (max 2 attempts)**. On failure, call `resetClient()` to close and null the cached client, then retry once so the current batch can recover on reconnect.
- **`recv()` failures are NOT retried** — once a stream is established the server may have already processed the payload; retrying would duplicate spans/metrics. The client is still reset so the *next* batch reconnects cleanly.
- **gRPC-level errors** (`grpc-status != 0`) are not retried — those are application errors, not transport failures.
- Extracted `resetClient()` private helper.
- Moved request building outside the retry loop (pure computation, no reason to repeat it).

### Tests

Three new tests added to `SwooleGrpcTransportTest`:
- `testSendResetsClientWhenStreamIdIsFalse` — verifies `$this->client` is nulled after a send failure
- `testSendResetsClientWhenRecvReturnsFalse` — verifies `$this->client` is nulled after a recv failure
- `testSendDoesNotRetryAfterRecvFailure` — verifies `recv()` is called exactly once (no retry on ambiguous outcome)

## Note on Bug 2

Bug 2 (HTTP `eventLoop already created`) was already fixed in v0.3.1 via `HyperfGuzzle` + `Discovery::setDiscoverers()` in `ConfigProvider`. No changes needed there.