### PR TITLE
fix(grpc): resilient SwooleGrpcTransport — mutex, retry, reconnect and PHP 8.2 compat

### DIFF
--- a/src/Factory/Log/Exporter/OtlpGrpcLogExporterFactory.php
+++ b/src/Factory/Log/Exporter/OtlpGrpcLogExporterFactory.php
@@ -6,6 +6,7 @@ namespace Hyperf\OpenTelemetry\Factory\Log\Exporter;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\OpenTelemetry\Transport\SwooleGrpcTransportFactory;
+use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use OpenTelemetry\Contrib\Otlp\LogsExporter;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Logs\LogRecordExporterInterface;
@@ -28,7 +29,7 @@ class OtlpGrpcLogExporterFactory implements LogExporterFactoryInterface
         return new LogsExporter(
             (new SwooleGrpcTransportFactory())->create(
                 endpoint: $endpoint,
-                contentType: 'application/x-protobuf',
+                contentType: ContentTypes::PROTOBUF,
                 headers: $options['headers'] ?? [],
                 compression: $options['compression'] ?? TransportFactoryInterface::COMPRESSION_GZIP,
                 timeout: $options['timeout'] ?? 10,

--- a/src/Factory/Metric/Exporter/OtlpGrpcMetricExporterFactory.php
+++ b/src/Factory/Metric/Exporter/OtlpGrpcMetricExporterFactory.php
@@ -6,6 +6,7 @@ namespace Hyperf\OpenTelemetry\Factory\Metric\Exporter;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\OpenTelemetry\Transport\SwooleGrpcTransportFactory;
+use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use OpenTelemetry\Contrib\Otlp\MetricExporter;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Metrics\Data\Temporality;
@@ -24,12 +25,12 @@ class OtlpGrpcMetricExporterFactory implements MetricExporterFactoryInterface
     {
         $options = $this->config->get('open-telemetry.metrics.exporters.otlp_grpc.options', []);
 
-        $endpoint = rtrim($options['endpoint'], '/') . self::GRPC_METHOD;
+        $endpoint = rtrim($options['endpoint'] ?? 'http://localhost:4317', '/') . self::GRPC_METHOD;
 
         return new MetricExporter(
             transport: (new SwooleGrpcTransportFactory())->create(
                 endpoint: $endpoint,
-                contentType: 'application/x-protobuf',
+                contentType: ContentTypes::PROTOBUF,
                 headers: $options['headers'] ?? [],
                 compression: $options['compression'] ?? TransportFactoryInterface::COMPRESSION_GZIP,
                 timeout: $options['timeout'] ?? 10,

--- a/src/Factory/Trace/Exporter/OtlpGrpcTraceExporterFactory.php
+++ b/src/Factory/Trace/Exporter/OtlpGrpcTraceExporterFactory.php
@@ -6,6 +6,7 @@ namespace Hyperf\OpenTelemetry\Factory\Trace\Exporter;
 
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\OpenTelemetry\Transport\SwooleGrpcTransportFactory;
+use OpenTelemetry\Contrib\Otlp\ContentTypes;
 use OpenTelemetry\Contrib\Otlp\SpanExporter;
 use OpenTelemetry\SDK\Common\Export\TransportFactoryInterface;
 use OpenTelemetry\SDK\Trace\SpanExporterInterface;
@@ -23,12 +24,12 @@ class OtlpGrpcTraceExporterFactory implements TraceExporterFactoryInterface
     {
         $options = $this->config->get('open-telemetry.traces.exporters.otlp_grpc.options', []);
 
-        $endpoint = rtrim($options['endpoint'], '/') . self::GRPC_METHOD;
+        $endpoint = rtrim($options['endpoint'] ?? 'http://localhost:4317', '/') . self::GRPC_METHOD;
 
         return new SpanExporter(
             (new SwooleGrpcTransportFactory())->create(
                 endpoint: $endpoint,
-                contentType: 'application/x-protobuf',
+                contentType: ContentTypes::PROTOBUF,
                 headers: $options['headers'] ?? [],
                 compression: $options['compression'] ?? TransportFactoryInterface::COMPRESSION_GZIP,
                 timeout: $options['timeout'] ?? 10,

--- a/src/Listener/OtelShutdownListener.php
+++ b/src/Listener/OtelShutdownListener.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Hyperf\OpenTelemetry\Listener;
 
+use Hyperf\Command\Event\AfterExecute;
+use Hyperf\Command\Event\AfterHandle;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Coroutine\Coroutine;
 use Hyperf\Event\Contract\ListenerInterface;
@@ -25,6 +27,8 @@ class OtelShutdownListener implements ListenerInterface
     {
         return [
             OnWorkerExit::class,
+            AfterHandle::class,
+            AfterExecute::class,
         ];
     }
 

--- a/src/SpanProcessor/ChannelBatchSpanProcessor.php
+++ b/src/SpanProcessor/ChannelBatchSpanProcessor.php
@@ -49,19 +49,6 @@ class ChannelBatchSpanProcessor implements SpanProcessorInterface
     ) {
     }
 
-    private function ensureInitialized(): void
-    {
-        if ($this->initialized) {
-            return;
-        }
-
-        $this->initialized = true;
-        $this->exportContext = Context::getCurrent();
-        $this->channel = new Channel($this->channelCapacity);
-        $this->startConsumer();
-        $this->startFlushTimer();
-    }
-
     public function onStart(ReadWriteSpanInterface $span, ContextInterface $parentContext): void
     {
     }
@@ -114,6 +101,19 @@ class ChannelBatchSpanProcessor implements SpanProcessorInterface
         $this->channel?->close();
 
         return $this->exporter->shutdown($cancellation);
+    }
+
+    private function ensureInitialized(): void
+    {
+        if ($this->initialized) {
+            return;
+        }
+
+        $this->initialized = true;
+        $this->exportContext = Context::getCurrent();
+        $this->channel = new Channel($this->channelCapacity);
+        $this->startConsumer();
+        $this->startFlushTimer();
     }
 
     private function pushBatch(): void

--- a/src/Transport/SwooleGrpcTransport.php
+++ b/src/Transport/SwooleGrpcTransport.php
@@ -12,6 +12,8 @@ use OpenTelemetry\SDK\Common\Future\CompletedFuture;
 use OpenTelemetry\SDK\Common\Future\ErrorFuture;
 use OpenTelemetry\SDK\Common\Future\FutureInterface;
 use RuntimeException;
+use Swoole\Coroutine;
+use Swoole\Coroutine\Channel;
 use Swoole\Coroutine\Http2\Client;
 use Swoole\Http2\Request;
 use Throwable;
@@ -21,6 +23,8 @@ final class SwooleGrpcTransport implements TransportInterface
     private bool $closed = false;
 
     private ?Client $client = null;
+
+    private ?Channel $mutex = null;
 
     /**
      * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
@@ -33,6 +37,8 @@ final class SwooleGrpcTransport implements TransportInterface
         private readonly float $timeout = 10.0,
         private readonly bool $ssl = false,
         private readonly ?string $compression = null,
+        private readonly int $retryDelay = 100,
+        private readonly int $maxRetries = 3,
     ) {
     }
 
@@ -47,42 +53,21 @@ final class SwooleGrpcTransport implements TransportInterface
             return new ErrorFuture(new RuntimeException('Transport is closed'));
         }
 
+        $mutex = $this->getMutex();
+        if ($mutex->pop() === false) {
+            return new ErrorFuture(new RuntimeException('Transport is closed'));
+        }
+
         try {
-            $client = $this->getClient();
-
-            $data = $this->compress($payload);
-
-            $request = new Request();
-            $request->method = 'POST';
-            $request->path = $this->method;
-            $request->headers = $this->buildHeaders();
-            $request->data = $this->packMessage($data);
-
-            $streamId = $client->send($request);
-
-            if ($streamId === false || $streamId <= 0) {
-                return new ErrorFuture(new RuntimeException(
-                    'Failed to send gRPC request: ' . ($client->errMsg ?: 'unknown error')
-                ));
+            if ($this->closed) {
+                return new ErrorFuture(new RuntimeException('Transport is closed'));
             }
 
-            $response = $client->recv($this->timeout);
-
-            if ($response === false) {
-                return new ErrorFuture(new RuntimeException(
-                    'Failed to receive gRPC response: ' . ($client->errMsg ?: 'timeout')
-                ));
-            }
-
-            $grpcStatus = $response->headers['grpc-status'] ?? '0';
-            if ($grpcStatus !== '0') {
-                $grpcMessage = $response->headers['grpc-message'] ?? 'Unknown error';
-                return new ErrorFuture(new RuntimeException("gRPC error: {$grpcMessage}", (int) $grpcStatus));
-            }
-
-            return new CompletedFuture(null);
+            return $this->attemptSend($payload);
         } catch (Throwable $e) {
             return new ErrorFuture($e);
+        } finally {
+            $mutex->push(true); // release — returns false silently if channel was closed by shutdown
         }
     }
 
@@ -93,6 +78,7 @@ final class SwooleGrpcTransport implements TransportInterface
         }
 
         $this->closed = true;
+        $this->mutex?->close(); // unblock any coroutines waiting to acquire the mutex
 
         if ($this->client !== null) {
             $this->client->close();
@@ -107,19 +93,126 @@ final class SwooleGrpcTransport implements TransportInterface
         return ! $this->closed;
     }
 
+    /**
+     * @SuppressWarnings(PHPMD.ErrorControlOperator)
+     */
+    private function attemptSend(string $payload): FutureInterface
+    {
+        $data = $this->compress($payload);
+        $lastError = null;
+
+        for ($attempt = 0; $attempt <= $this->maxRetries; ++$attempt) {
+            if ($this->closed) {
+                return new ErrorFuture(new RuntimeException('Transport is closed'));
+            }
+
+            if ($attempt > 0 && $this->retryDelay > 0) {
+                Coroutine::sleep($this->retryDelay / 1000.0);
+            }
+
+            try {
+                return $this->doRequest($this->getClient(), $data);
+            } catch (Throwable $e) {
+                $this->resetClient();
+                $lastError = $e;
+            }
+        }
+
+        return new ErrorFuture($lastError ?? new RuntimeException('Unknown transport error after retries'));
+    }
+
+    /**
+     * Executes a single gRPC send+recv cycle.
+     *
+     * Throws RuntimeException on send failure so the caller can reset the client and retry.
+     * Returns ErrorFuture on recv failure (delivery uncertain — no retry).
+     *
+     * Note: @$client->recv() suppresses E_DEPRECATED from Swoole setting $serverLastStreamId
+     * as a dynamic property in PHP 8.2+. Hyperf's ErrorExceptionHandler would otherwise convert
+     * the deprecation notice into an ErrorException, aborting the recv() call.
+     *
+     * @throws RuntimeException on retryable send failure
+     * @SuppressWarnings(PHPMD.ErrorControlOperator)
+     */
+    private function doRequest(Client $client, string $data): FutureInterface
+    {
+        $request = new Request();
+        $request->method = 'POST';
+        $request->path = $this->method;
+        $request->headers = $this->buildHeaders();
+        $request->data = $this->packMessage($data);
+
+        $streamId = $client->send($request);
+
+        if ($streamId === false || $streamId <= 0) {
+            // Throw so the retry loop can reset the client and try again;
+            // data was never transmitted so retrying is safe.
+            throw new RuntimeException(
+                'Failed to send gRPC request: ' . ($client->errMsg ?: 'unknown error')
+            );
+        }
+
+        $response = @$client->recv($this->timeout);
+
+        if ($response === false) {
+            $this->resetClient($client);
+            // Do not retry: send succeeded, so delivery is uncertain — retrying could duplicate exports.
+            return new ErrorFuture(new RuntimeException(
+                'Failed to receive gRPC response: ' . ($client->errMsg ?: 'timeout')
+            ));
+        }
+
+        $grpcStatus = (int) ($response->headers['grpc-status'] ?? 0);
+        if ($grpcStatus !== 0) {
+            $grpcMessage = $response->headers['grpc-message'] ?? 'Unknown error';
+            // gRPC application error — not retried
+            return new ErrorFuture(new RuntimeException("gRPC error: {$grpcMessage}", $grpcStatus));
+        }
+
+        return new CompletedFuture(null);
+    }
+
+    private function getMutex(): Channel
+    {
+        if ($this->mutex === null) {
+            $this->mutex = new Channel(1);
+            $this->mutex->push(true); // initially unlocked
+        }
+
+        return $this->mutex;
+    }
+
+    private function resetClient(?Client $client = null): void
+    {
+        $target = $client ?? $this->client;
+        $target?->close();
+        if ($target === $this->client) {
+            $this->client = null;
+        }
+    }
+
     private function getClient(): Client
     {
-        if ($this->client === null || ! $this->client->connected) {
-            $this->client = new Client($this->host, $this->port, $this->ssl);
-            $this->client->set([
+        if ($this->client !== null && ! $this->client->connected) {
+            $this->client->close();
+            $this->client = null;
+        }
+
+        if ($this->client === null) {
+            $client = new Client($this->host, $this->port, $this->ssl);
+            $client->set([
                 'timeout' => $this->timeout,
             ]);
 
-            if (! $this->client->connect()) {
+            if (! $client->connect()) {
+                $errMsg = $client->errMsg;
+                $client->close();
                 throw new RuntimeException(
-                    "Failed to connect to {$this->host}:{$this->port}: " . $this->client->errMsg
+                    "Failed to connect to {$this->host}:{$this->port}: " . $errMsg
                 );
             }
+
+            $this->client = $client;
         }
 
         return $this->client;
@@ -165,6 +258,7 @@ final class SwooleGrpcTransport implements TransportInterface
     private function packMessage(string $data): string
     {
         $compressed = $this->compression !== null ? 1 : 0;
+        // gRPC message frame: [1-byte compressed flag][4-byte big-endian message length][message]
         return pack('CN', $compressed, strlen($data)) . $data;
     }
 }

--- a/src/Transport/SwooleGrpcTransportFactory.php
+++ b/src/Transport/SwooleGrpcTransportFactory.php
@@ -11,6 +11,13 @@ use OpenTelemetry\SDK\Common\Export\TransportInterface;
 
 final class SwooleGrpcTransportFactory implements TransportFactoryInterface
 {
+    /**
+     * Note: $cacert, $cert, and $key are accepted to satisfy the TransportFactoryInterface
+     * contract but are not implemented in this transport. TLS certificates are not supported;
+     * use the https:// or grpcs:// scheme for basic TLS.
+     *
+     * @param null|mixed $compression
+     */
     public function create(
         string $endpoint,
         string $contentType = ContentTypes::PROTOBUF,
@@ -45,6 +52,13 @@ final class SwooleGrpcTransportFactory implements TransportFactoryInterface
             $compressionType = null;
         }
 
+        $supportedCompression = [null, TransportFactoryInterface::COMPRESSION_GZIP, TransportFactoryInterface::COMPRESSION_DEFLATE];
+        if (! in_array($compressionType, $supportedCompression, true)) {
+            throw new InvalidArgumentException(
+                sprintf('Unsupported compression type "%s"', $compressionType)
+            );
+        }
+
         return new SwooleGrpcTransport(
             host: $parsed['host'],
             port: $parsed['port'],
@@ -53,6 +67,8 @@ final class SwooleGrpcTransportFactory implements TransportFactoryInterface
             timeout: $timeout,
             ssl: $parsed['ssl'],
             compression: $compressionType,
+            retryDelay: $retryDelay,
+            maxRetries: $maxRetries,
         );
     }
 

--- a/tests/Unit/Factory/Metric/Exporter/OtlpGrpcMetricExporterFactoryTest.php
+++ b/tests/Unit/Factory/Metric/Exporter/OtlpGrpcMetricExporterFactoryTest.php
@@ -36,4 +36,17 @@ class OtlpGrpcMetricExporterFactoryTest extends TestCase
 
         $this->assertInstanceOf(MetricExporterInterface::class, $exporter);
     }
+
+    public function testMakeWithDefaultEndpoint(): void
+    {
+        $config = $this->createMock(ConfigInterface::class);
+        $config->method('get')
+            ->with('open-telemetry.metrics.exporters.otlp_grpc.options', [])
+            ->willReturn([]);
+
+        $factory = new OtlpGrpcMetricExporterFactory($config);
+        $exporter = $factory->make();
+
+        $this->assertInstanceOf(MetricExporterInterface::class, $exporter);
+    }
 }

--- a/tests/Unit/Factory/Trace/Exporter/OtlpGrpcTraceExporterFactoryTest.php
+++ b/tests/Unit/Factory/Trace/Exporter/OtlpGrpcTraceExporterFactoryTest.php
@@ -34,4 +34,17 @@ class OtlpGrpcTraceExporterFactoryTest extends TestCase
 
         $this->assertInstanceOf(SpanExporterInterface::class, $exporter);
     }
+
+    public function testMakeWithDefaultEndpoint(): void
+    {
+        $config = $this->createMock(ConfigInterface::class);
+        $config->method('get')
+            ->with('open-telemetry.traces.exporters.otlp_grpc.options', [])
+            ->willReturn([]);
+
+        $factory = new OtlpGrpcTraceExporterFactory($config);
+        $exporter = $factory->make();
+
+        $this->assertInstanceOf(SpanExporterInterface::class, $exporter);
+    }
 }

--- a/tests/Unit/Listener/OtelShutdownListenerTest.php
+++ b/tests/Unit/Listener/OtelShutdownListenerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Listener;
 
+use Hyperf\Command\Event\AfterExecute;
+use Hyperf\Command\Event\AfterHandle;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Event\Contract\ListenerInterface;
 use Hyperf\Framework\Event\OnWorkerExit;
@@ -36,7 +38,7 @@ class OtelShutdownListenerTest extends TestCase
             $this->createMock(TracerProviderInterface::class),
             $this->createMock(StdoutLoggerInterface::class)
         );
-        $this->assertSame([OnWorkerExit::class], $listener->listen());
+        $this->assertSame([OnWorkerExit::class, AfterHandle::class, AfterExecute::class], $listener->listen());
     }
 
     public function testProcessCallsShutdownInsideCoroutine(): void

--- a/tests/Unit/Transport/SwooleGrpcTransportFactoryTest.php
+++ b/tests/Unit/Transport/SwooleGrpcTransportFactoryTest.php
@@ -119,4 +119,35 @@ class SwooleGrpcTransportFactoryTest extends TestCase
         $compressionProp = $reflection->getProperty('compression');
         $this->assertNull($compressionProp->getValue($transport));
     }
+
+    public function testCreateWithRetryParameters(): void
+    {
+        $factory = new SwooleGrpcTransportFactory();
+
+        $transport = $factory->create(
+            endpoint: 'http://localhost:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export',
+            contentType: ContentTypes::PROTOBUF,
+            retryDelay: 200,
+            maxRetries: 5,
+        );
+
+        $reflection = new ReflectionClass($transport);
+
+        $this->assertSame(200, $reflection->getProperty('retryDelay')->getValue($transport));
+        $this->assertSame(5, $reflection->getProperty('maxRetries')->getValue($transport));
+    }
+
+    public function testCreateThrowsExceptionForUnsupportedCompression(): void
+    {
+        $factory = new SwooleGrpcTransportFactory();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unsupported compression type "br"');
+
+        $factory->create(
+            endpoint: 'http://localhost:4317/opentelemetry.proto.collector.trace.v1.TraceService/Export',
+            contentType: ContentTypes::PROTOBUF,
+            compression: 'br',
+        );
+    }
 }


### PR DESCRIPTION
## Description

Fixes three production bugs in `SwooleGrpcTransport` reported via error logs, plus a suite of structural improvements identified during code review.

### Bug fixes

| Error | Root cause | Fix |
|---|---|---|
| `Broken pipe` — batch lost | Stale HTTP/2 connection not detected; no retry | Retry loop on send failure (`attemptSend`): reset client + reconnect up to `maxRetries` |
| `Creation of dynamic property ... deprecated` — recv aborted | Swoole sets `$serverLastStreamId` dynamically; Hyperf's `ErrorExceptionHandler` converts `E_DEPRECATED` → `ErrorException` | `@$client->recv()` suppresses the notice before Hyperf's handler sees it |
| Race condition — concurrent coroutines corrupt shared `$client` | No synchronisation on `send()` | `Channel(1)` as a coroutine-safe mutex; `shutdown()` closes the channel to unblock waiting coroutines without deadlock |

Recv failures are **not** retried intentionally: once `send()` succeeds, delivery is uncertain and retrying DELTA metric exports risks duplication.

### Structural improvements

- `retryDelay` / `maxRetries` now wired from factory → transport constructor (previously silently discarded)
- Endpoint fallback (`http://localhost:4317`) added to Trace and Metric gRPC factories
- `'application/x-protobuf'` string literals replaced with `ContentTypes::PROTOBUF` constant
- `getClient()` now closes stale (disconnected) clients before reconnecting
- `resetClient()` closes the socket before nulling the reference (avoids leaking dead sockets)
- Compression type validated in factory — prevents `compressed_flag=1` with uncompressed payload
- `grpc-status` cast to `int` before comparison (more robust against whitespace / non-conformant servers)
- `attemptSend` extracted into `doRequest` to reduce cyclomatic complexity below PHPMD threshold
- gRPC framing comment added to `packMessage`

### Also in this PR

- `feat(shutdown)`: flush OTel on `AfterHandle` / `AfterExecute` events so CLI commands flush spans on exit
- `style`: fix method ordering in `ChannelBatchSpanProcessor` per PHP-CS-Fixer rule

## Type of change
- [x] Bug fix
- [x] Performance/Refactor

## Checklist
- [x] Title follows *Conventional Commits*
- [x] Tests added/updated
- [x] `composer test` passes locally (184 tests, 461 assertions)
- [ ] Documentation updated (README/Docs)
- [x] No breaking changes

## Related issues
https://github.com/opencodeco/hyperf-opentelemetry/issues/23